### PR TITLE
Adds a Docker multistage build and a Thorntail profile

### DIFF
--- a/Container/Dockerfile
+++ b/Container/Dockerfile
@@ -1,0 +1,11 @@
+FROM centos:7
+LABEL Author="Michal Karm Babacek <karm@redhat.com>"
+ENV JAVA_VERSION 1.8.0
+RUN yum install java-${JAVA_VERSION}-openjdk-headless -y && yum clean all && rm -rf /var/cache/yum /tmp/* && \
+    useradd -s /sbin/nologin wildfly
+EXPOSE 8080/tcp
+USER wildfly
+WORKDIR /opt/
+COPY --chown=wildfly:wildfly target/mp-starter-hollow-thorntail /opt/mp-starter-hollow-thorntail
+COPY --chown=wildfly:wildfly target/mp-starter.war Container/start.sh /opt/
+CMD ["/opt/start.sh"]

--- a/Container/Dockerfile.CI
+++ b/Container/Dockerfile.CI
@@ -1,0 +1,35 @@
+# Multi-stage build (Docker 17.05 or higher)
+
+# build stage
+#############
+FROM centos:7 AS build-env
+LABEL Author="Michal Karm Babacek <karm@redhat.com>"
+WORKDIR /opt
+ENV MVN_VERSION  3.3.9
+ENV JAVA_VERSION 1.8.0
+ENV M2_HOME /opt/apache-maven-${MVN_VERSION}
+ENV JAVA_HOME /usr/lib/jvm/jre-${JAVA_VERSION}-openjdk
+RUN yum install java-${JAVA_VERSION}-openjdk-devel unzip -y
+RUN curl -L -O https://www-eu.apache.org/dist/maven/maven-3/${MVN_VERSION}/binaries/apache-maven-${MVN_VERSION}-bin.zip && \
+    unzip apache-maven-${MVN_VERSION}-bin.zip
+COPY src ./src
+COPY pom.xml ./
+COPY Container/settings.xml /root/.m2/settings.xml
+COPY Container/start.sh /opt/
+RUN  ./apache-maven-${MVN_VERSION}/bin/mvn package -Pthorntail && \
+     unzip target/mp-starter-hollow-thorntail.jar -d target/mp-starter-hollow-thorntail
+
+
+# prod stage
+#############
+FROM centos:7
+LABEL Author="Michal Karm Babacek <karm@redhat.com>"
+ENV JAVA_VERSION 1.8.0
+RUN yum install java-${JAVA_VERSION}-openjdk-headless -y && yum clean all && \
+    rm -rf /var/cache/yum /tmp/* && useradd -s /sbin/nologin wildfly
+EXPOSE 8080/tcp
+USER wildfly
+WORKDIR /opt/
+COPY --from=build-env --chown=wildfly:wildfly /opt/target/mp-starter-hollow-thorntail /opt/mp-starter-hollow-thorntail
+COPY --from=build-env --chown=wildfly:wildfly /opt/start.sh /opt/target/mp-starter.war /opt/
+CMD ["/opt/start.sh"]

--- a/Container/README.md
+++ b/Container/README.md
@@ -1,0 +1,233 @@
+Building an image and running a container
+=========================================
+
+Development workflow
+====================
+
+Locally without Docker
+----------------------
+
+```
+mvn thorntail:run -Pthorntail
+
+```
+
+Navigate to 127.0.0.1:8080 or http://127.0.0.1:8080/index.xhtml to see the app.
+
+Docker build
+------------
+With at least Docker 17.05, one can build an image and either run it locally or push it to a registry.
+Please note that the first build takes time, but subsequent runs add merely ```~12M``` of the war file.
+
+```
+mvn package -Pthorntail && unzip target/mp-starter-hollow-thorntail.jar -d target/mp-starter-hollow-thorntail
+docker build -f Container/Dockerfile -t microprofile/start.microprofile.io:1.0-SNAPSHOT .
+```
+
+Run locally
+-----------
+
+```
+docker run -p 127.0.0.1:8080:8080/tcp -d -i --name mp-starter microprofile/start.microprofile.io:1.0-SNAPSHOT
+docker stop -t 2 mp-starter && docker rm mp-starter
+```
+
+Push image to registry and restart service
+------------------------------------------
+
+```
+docker push microprofile/start.microprofile.io:1.0-SNAPSHOT
+ssh ec2-user@aws-microstarter "sudo systemctl restart docker-compose@start.microprofile.io"
+```
+
+Subsequent pushes just upload ```~12M``` of the war file.
+
+Example flow
+------------
+
+```
+mvn package -Pthorntail && unzip target/mp-starter-hollow-thorntail.jar -d target/mp-starter-hollow-thorntail
+docker build -f Container/Dockerfile -t microprofile/start.microprofile.io:1.0-SNAPSHOT .
+docker push microprofile/start.microprofile.io:1.0-SNAPSHOT
+ssh ec2-user@aws-microstarter "sudo systemctl restart docker-compose@start.microprofile.io"
+```
+
+Recorded
+--------
+[![asciicast](https://asciinema.org/a/217550.svg)](https://asciinema.org/a/217550)
+
+
+Production and CI
+=================
+
+The Dockerfile is a [multi-staged build](https://docs.docker.com/develop/develop-images/multistage-build).
+The first stage downloads Maven, installs OpenJDK Devel, builds the application.
+
+The second stage installs just OpenJDK Headless JVM and adds the uberjar contents from the previous stage.
+
+Due to the application's dependency on JSF the image is very fat.
+Refactoring the app so as it runs just with a plain servlet container is a possible improvement to be made.
+
+Building an image
+-----------------
+Note the tag ```microprofile/start.microprofile.io:1.0-SNAPSHOT``` is an example and you should use your own namespace.
+
+```
+docker build -f Container/Dockerfile.CI -t microprofile/start.microprofile.io:1.0-SNAPSHOT .
+```
+
+One can push the built image to a public DockerHub (one needs an account though):
+
+```
+docker push microprofile/start.microprofile.io:1.0-SNAPSHOT
+```
+
+Running a container locally
+---------------------------
+The container accepts several environment properties one should use them to tweak the server.
+
+```
+docker run -e MY_LOGLEVEL=INFO \
+              -e MY_IO_THREADS="8" \
+              -e MY_TASK_MAX_THREADS="64" \
+              -e MY_HTTP_PORT="8080" \
+              -e MY_HTTPS_PORT="8443" \
+              -e MY_MS_HEAP="64m" \
+              -e MY_MX_HEAP="512m" \
+              -e MY_META_SPACE="96M" \
+              -e MY_MAX_META_SPACE="256m" \
+   -p 127.0.0.1:8080:8080/tcp -d -i --name mp-starter microprofile/start.microprofile.io:1.0-SNAPSHOT
+```
+
+One can watch the logs:
+
+```
+docker logs -f mp-starter
+```
+
+You can stop and remove it as:
+
+```
+docker stop -t 2 mp-starter && docker rm mp-starter
+```
+
+Debugging the image build
+-------------------------
+One can skip the final stage of the multistage build and just do the first stage:
+
+```
+docker build --target build-env -f Container/Dockerfile.CI -t microprofile/start.microprofile.io:1.0-SNAPSHOT .
+```
+
+You can start bash and look around without starting the application:
+
+```
+docker run -i --entrypoint=/bin/bash --name mp-starter microprofile/start.microprofile.io:1.0-SNAPSHOT
+```
+
+If you have the container running already and you want to examine it, you can:
+
+```
+docker exec -t -i mp-starter bash
+```
+
+
+Using Systemd and Docker Compose
+================================
+
+If you don't need any orchestration and you would just like to play with the container on a single host,
+the following might come handy.
+
+Get a VM on the Internet
+------------------------
+
+After you are done installing Docker (use your package manager of choice) and Docker compose, e.g.
+
+```
+curl -L https://github.com/docker/compose/releases/download/1.23.2/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
+chmod +x /usr/local/bin/docker-compose
+```
+
+Compose
+-------
+
+Have a Docker compose file created with env variables for the container. This example uses a small 1 vCPU 1G RAM VM.
+Mind the name "mp-starter" in the path to the file.
+
+```
+cat /etc/docker/compose/mp-starter/docker-compose.yml
+version: '3'
+services:
+  mp-starter:
+    image: "microprofile/start.microprofile.io:1.0-SNAPSHOT"
+    user: wildfly
+    ports:
+      - 443:8443
+      - 80:8080
+    restart: always
+    environment:
+      MY_LOGLEVEL:         "INFO"
+      MY_IO_THREADS:       "2"
+      MY_TASK_MAX_THREADS: "32"
+      MY_MS_HEAP:          "512m"
+      MY_MX_HEAP:          "512m"
+      MY_META_SPACE:       "96M"
+      MY_MAX_META_SPACE:   "256m"
+```
+
+Systemd unit
+------------
+
+Next, let's create a Systemd unit that would control Docker compose:
+
+```
+cat /etc/systemd/system/docker-compose@.service
+[Unit]
+Description=%i service with docker compose
+Requires=docker.service
+After=docker.service
+[Service]
+Restart=always
+WorkingDirectory=/etc/docker/compose/%i
+# Remove old containers, images and volumes
+ExecStartPre=/usr/local/bin/docker-compose down -v
+ExecStartPre=/usr/local/bin/docker-compose rm -fv
+ExecStartPre=-/bin/bash -c 'docker volume ls -qf "name=%i_" | xargs docker volume rm'
+ExecStartPre=-/bin/bash -c 'docker network ls -qf "name=%i_" | xargs docker network rm'
+ExecStartPre=-/bin/bash -c 'docker ps -aqf "name=%i_*" | xargs docker rm'
+# Pull updated layers
+ExecStartPre=-/usr/local/bin/docker-compose pull
+# Compose up
+ExecStart=/usr/local/bin/docker-compose up
+# Compose down, remove containers and volumes
+ExecStop=/usr/local/bin/docker-compose down -v
+[Install]
+WantedBy=multi-user.target
+```
+
+We can enable the unit now to have it running on VM startup:
+
+```
+systemctl enable docker-compose@mp-starter
+```
+
+And let's start it and give it a try:
+
+```
+systemctl start docker-compose@mp-starter
+```
+
+Verify it is running:
+
+```
+docker ps -a
+curl localhost
+```
+
+Although one probably cannot access it from the outside due to a firewall your IaaS provider has in place, so let's configure the Security Group/Firewall/Network Security, depends on your provider.
+
+We haven't setup our own TLS infrastructure nor we have Elytron in Wildfly configured with Let's Encrypt, so let's hide
+the system behind Cloudflare's balancer. This is the list of Cloudflare's IP ranges we are going to allow inbound traffic from: https://www.cloudflare.com/ips/
+
+Now if you configure your domain and enforce HTTPS with Cloudflare you get your application running and accessible from
+the Internet on HTTPS only.

--- a/Container/settings.xml
+++ b/Container/settings.xml
@@ -1,0 +1,12 @@
+<settings>
+    <!-- Set to US/LATAM/APAC if it suits you better. EU is the default. -->
+    <mirrors>
+        <!-- Mirror for the Central -->
+        <mirror>
+            <id>google-maven-central</id>
+            <name>GCS Maven Central mirror EU</name>
+            <url>https://maven-central-eu.storage-download.googleapis.com/repos/central/data/</url>
+            <mirrorOf>central</mirrorOf>
+        </mirror>
+    </mirrors>
+</settings>

--- a/Container/start.sh
+++ b/Container/start.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# @author Michal Karm Babacek
+
+# Assigned by the container
+export HOSTNAME=`hostname`
+
+# Run
+java -server \
+ -Xms${MY_MS_HEAP:-64m} \
+ -Xmx${MY_MX_HEAP:-512m} \
+ -XX:MetaspaceSize=${MY_META_SPACE:-96M} \
+ -XX:MaxMetaspaceSize=${MY_MAX_META_SPACE:-256m} \
+ -XX:+UseG1GC \
+ -XX:+HeapDumpOnOutOfMemoryError \
+ -XX:HeapDumpPath=/opt/mp-starter-hollow-thorntail/ \
+ -cp /opt/mp-starter-hollow-thorntail \
+ org.wildfly.swarm.bootstrap.Main \
+ /opt/mp-starter.war \
+ -Dswarm.io.workers.default.io-threads=${MY_IO_THREADS:-8} \
+ -Dswarm.io.workers.default.task-max-threads=${MY_TASK_MAX_THREADS:-64} \
+ -Dswarm.transactions.node-identifier=666 \
+ -Dswarm.logging.root-logger.level=${MY_LOGLEVEL:-INFO} \
+ -Dswarm.http.port=${MY_HTTP_PORT:-8080} \
+ -Dswarm.https.port=${MY_HTTPS_PORT:-8443} \
+ -Dswarm.undertow.servers.default-server.hosts.default-host.alias="${HOSTNAME}" \
+ -Dswarm.bind.address="${HOSTNAME}"

--- a/pom.xml
+++ b/pom.xml
@@ -37,16 +37,21 @@
     <inceptionYear>2017</inceptionYear>
 
     <properties>
+        <version.thorntail>2.2.1.Final</version.thorntail>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-
         <failOnMissingWebXml>false</failOnMissingWebXml>
-
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.model.builder.version>3.3.9</maven.model.builder.version>
         <deltaspike.version>1.8.1</deltaspike.version>
-
+        <jackson.dataformat.yaml.version>2.8.5</jackson.dataformat.yaml.version>
+        <jackson.databind.version>2.8.5</jackson.databind.version>
         <primefaces.version>6.1</primefaces.version>
         <atbash-utils.version>0.9.1</atbash-utils.version>
+        <thymeleaf.version>3.0.2.RELEASE</thymeleaf.version>
+        <reflections.version>0.9.11</reflections.version>
     </properties>
+    
     <dependencies>
         <dependency>
             <groupId>javax</groupId>
@@ -90,39 +95,90 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-model-builder</artifactId>
-            <version>3.3.9</version>
+            <version>${maven.model.builder.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>2.8.5</version>
+            <version>${jackson.dataformat.yaml.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.8.5</version>
+            <version>${jackson.databind.version}</version>
         </dependency>
-
 
         <!-- templating -->
         <dependency>
             <groupId>org.thymeleaf</groupId>
             <artifactId>thymeleaf</artifactId>
-            <version>3.0.2.RELEASE</version>
+            <version>${thymeleaf.version}</version>
         </dependency>
 
         <!-- looking up all resource files -->
         <dependency>
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
-            <version>0.9.11</version>
+            <version>${reflections.version}</version>
         </dependency>
-
     </dependencies>
 
     <build>
         <finalName>mp-starter</finalName>
     </build>
+    
+    <profiles>
+        <profile>
+            <id>thorntail</id>
+            <dependencies>
+                <dependency>
+                    <groupId>io.thorntail</groupId>
+                    <artifactId>jsf</artifactId>
+                </dependency>
+
+                <dependency>
+                    <groupId>io.thorntail</groupId>
+                    <artifactId>cdi</artifactId>
+                </dependency>
+            </dependencies>
+
+            <dependencyManagement>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.thorntail</groupId>
+                        <artifactId>bom-all</artifactId>
+                        <version>${version.thorntail}</version>
+                        <scope>import</scope>
+                        <type>pom</type>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
+
+            <build>
+                <finalName>mp-starter</finalName>
+                <plugins>
+                    <plugin>
+                        <groupId>io.thorntail</groupId>
+                        <artifactId>thorntail-maven-plugin</artifactId>
+                        <version>${version.thorntail}</version>
+                        <configuration>
+                            <!-- Since Thorntail 4 https://docs.thorntail.io/4.0.0-SNAPSHOT/#_modes
+                            <mode>thin</mode>
+                            <format>dir</format>-->
+                            <hollow>true</hollow>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>package</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
The commit adds Container directory with a comprehensive README.md covering
building and running the Docker image. Dockerfile sports a multi-stage build.

One can use mvn thorntail:run -Pthorntail for development.

See Container/start.sh for some Thorntail specific properties set at container runtime.

There is not technical reason why the runtime whould have to be Thorntail,
it can be replaced with a differnet server.

Signed-off-by: Michal Karm Babacek karm@fedoraproject.org