### PR TITLE
Adds links and badges to site monitoring service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # microprofile-starter
 
 [![Gitter](https://badges.gitter.im/eclipse/microprofile-starter.svg)](https://gitter.im/eclipse/microprofile-starter?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Uptime Robot status](https://img.shields.io/uptimerobot/ratio/7/m781918689-6f2e0769420600bd3138f478.svg?style=flat-square)](https://stats.karms.biz/781918689)[![Uptime Robot status](https://img.shields.io/uptimerobot/status/m781918689-6f2e0769420600bd3138f478.svg?style=flat-square)](https://stats.karms.biz/781918689)
 
 Live tool at [MicroProfile starter - Generate MicroProfile Maven Project](https://start.microprofile.io/index.xhtml)
 


### PR DESCRIPTION
This is what it looks like in Markdown:

[![Uptime Robot status](https://img.shields.io/uptimerobot/ratio/7/m781918689-6f2e0769420600bd3138f478.svg?style=flat-square)](https://stats.karms.biz/781918689)[![Uptime Robot status](https://img.shields.io/uptimerobot/status/m781918689-6f2e0769420600bd3138f478.svg?style=flat-square)](https://stats.karms.biz/781918689)

It uses my Uptime Robot account though. Do we want it? Do we want it, but with a separate account?

This is juts a little thing someone might find nice to have.  Close the PR if it is not the case. 

Signed-off-by: Michal Karm Babacek <karm@fedoraproject.org>
