### PR TITLE
Adds Wildfly java style coding rules for Checkstyle plugin

### DIFF
--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!--
+    Copyright (c) 2019 Contributors to the Eclipse Foundation
+
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    You may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!DOCTYPE suppressions PUBLIC
+        "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+        "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+    <suppress checks="AvoidStarImport" message="Using the '.*' form of import should be avoided - java.util.*" files=".java"/>
+</suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -51,8 +51,9 @@
         <thymeleaf.version>3.0.10.RELEASE</thymeleaf.version>
         <junit.version>4.12</junit.version>
 
-        <checkstyle.version>2.17</checkstyle.version>
-        <checkstyle.methodNameFormat>^_?[a-z][a-zA-Z0-9]*$</checkstyle.methodNameFormat>
+        <maven.checkstyle.plugin.version>3.0.0</maven.checkstyle.plugin.version>
+        <checkstyle.version>8.10.1</checkstyle.version>
+        <org.wildfly.checkstyle-config.version>1.0.7.Final</org.wildfly.checkstyle-config.version>
     </properties>
 
     <dependencies>
@@ -109,7 +110,19 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>${checkstyle.version}</version>
+                    <version>${maven.checkstyle.plugin.version}</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.puppycrawl.tools</groupId>
+                            <artifactId>checkstyle</artifactId>
+                            <version>${checkstyle.version}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.wildfly.checkstyle</groupId>
+                            <artifactId>wildfly-checkstyle-config</artifactId>
+                            <version>${org.wildfly.checkstyle-config.version}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -117,93 +130,23 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>${maven.checkstyle.plugin.version}</version>
                 <executions>
                     <execution>
-                        <id>verify-style</id>
-                        <phase>process-classes</phase>
+                        <id>check-style</id>
+                        <phase>compile</phase>
                         <goals>
-                            <goal>check</goal>
+                            <goal>checkstyle</goal>
                         </goals>
                     </execution>
                 </executions>
                 <configuration>
-                    <encoding>UTF-8</encoding>
+                    <configLocation>wildfly-checkstyle/checkstyle.xml</configLocation>
                     <consoleOutput>true</consoleOutput>
-                    <failOnViolation>true</failOnViolation>
-                    <includeTestSourceDirectory>true</includeTestSourceDirectory>
                     <failsOnError>true</failsOnError>
-                    <linkXRef>true</linkXRef>
-                    <logViolationsToConsole>true</logViolationsToConsole>
-                    <checkstyleRules>
-                        <module name="Checker">
-                            <module name="SuppressionCommentFilter"/>
-                            <module name="FileLength">
-                                <property name="max" value="3500"/>
-                                <property name="fileExtensions" value="java"/>
-                            </module>
-                            <module name="FileTabCharacter"/>
-                            <module name="TreeWalker">
-                                <module name="FileContentsHolder"/>
-                                <module name="ConstantName">
-                                    <property name="format" value="^(([A-Z][A-Z0-9]*(_[A-Z0-9]+)*))$"/>
-                                </module>
-                                <module name="LocalVariableName"/>
-                                <module name="MethodName">
-                                    <property name="format" value="${checkstyle.methodNameFormat}"/>
-                                </module>
-                                <module name="PackageName"/>
-                                <module name="LocalFinalVariableName"/>
-                                <module name="ParameterName"/>
-                                <module name="StaticVariableName"/>
-
-                                <module name="TypeName">
-                                    <property name="format" value="^_?[A-Z][a-zA-Z0-9]*$|packageinfo"/>
-                                </module>
-                                <module name="AvoidStarImport">
-                                    <property name="excludes"
-                                              value="java.io,java.net,java.util,javax.enterprise.inject.spi,javax.enterprise.context"/>
-                                </module>
-                                <module name="IllegalImport"/>
-                                <module name="RedundantImport"/>
-                                <module name="UnusedImports"/>
-                                <module name="LineLength">
-                                    <property name="max" value="150"/>
-                                    <property name="ignorePattern" value="@version|@see"/>
-                                </module>
-                                <module name="MethodLength">
-                                    <property name="max" value="250"/>
-                                </module>
-                                <module name="ParameterNumber">
-                                    <property name="max" value="11"/>
-                                </module>
-                                <module name="EmptyBlock">
-                                    <property name="option" value="text"/>
-                                </module>
-                                <module name="NeedBraces"/>
-                                <module name="LeftCurly">
-                                    <property name="option" value="EOL"/>
-                                </module>
-                                <module name="RightCurly"/>
-                                <module name="EmptyStatement"/>
-                                <module name="EqualsHashCode"/>
-                                <module name="DefaultComesLast"/>
-                                <module name="MissingSwitchDefault"/>
-                                <module name="FallThrough"/>
-                                <module name="MultipleVariableDeclarations"/>
-                                <module name="com.puppycrawl.tools.checkstyle.checks.design.DesignForExtensionCheck">
-                                    <property name="severity" value="ignore"/>
-                                </module>
-                                <module name="HideUtilityClassConstructor"/>
-                                <module name="com.puppycrawl.tools.checkstyle.checks.design.VisibilityModifierCheck">
-                                    <property name="packageAllowed" value="false"/>
-                                    <property name="protectedAllowed" value="true"/>
-                                    <property name="publicMemberPattern" value="^serialVersionUID"/>
-                                    <property name="severity" value="warning"/>
-                                </module>
-                                <module name="UpperEll"/>
-                            </module>
-                        </module>
-                    </checkstyleRules>
+                    <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                    <suppressionsLocation>checkstyle-suppressions.xml</suppressionsLocation>
+                    <useFile></useFile>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/org/eclipse/microprofile/starter/core/model/JessieModel.java
+++ b/src/main/java/org/eclipse/microprofile/starter/core/model/JessieModel.java
@@ -122,6 +122,7 @@ public class JessieModel {
         parameters.put(parameter.name(), value);
     }
 
+    @SuppressWarnings("unchecked")
     public <T extends Serializable> T getParameter(Parameter parameter) {
         return (T) parameters.get(parameter.name());
     }

--- a/src/main/java/org/eclipse/microprofile/starter/core/templates/TemplateModelLoader.java
+++ b/src/main/java/org/eclipse/microprofile/starter/core/templates/TemplateModelLoader.java
@@ -60,6 +60,7 @@ public class TemplateModelLoader {
         }
 
         InputStream resource = this.getClass().getClassLoader().getResourceAsStream("templates/templates.yaml");
+        @SuppressWarnings("unchecked")
         List<String> templateFiles = yamlReader.readYAML(resource, List.class);
         // FIXME mechanism to define custom templates.
         try {

--- a/src/main/java/org/eclipse/microprofile/starter/log/DynamoDBLogger.java
+++ b/src/main/java/org/eclipse/microprofile/starter/log/DynamoDBLogger.java
@@ -67,7 +67,7 @@ public class DynamoDBLogger {
     }
 
     private static byte[] signatureKey(
-            final String key, final String dateStamp, final String regionName, final String serviceName) 
+            final String key, final String dateStamp, final String regionName, final String serviceName)
             throws NoSuchAlgorithmException, InvalidKeyException {
         final byte[] kDate = sign(StandardCharsets.UTF_8.encode("AWS4" + key).array(), StandardCharsets.UTF_8.encode(dateStamp).array());
         final byte[] kRegion = sign(kDate, StandardCharsets.US_ASCII.encode(regionName).array());


### PR DESCRIPTION
The commit adds Wildfly coding style rules as a maven dependency,
Apache 2 license [1]. Plus it adds checkstyle-suppressions.xml file
that explicitly white lists star imports of java.util.* as they
are used in the project and I don't see any real evil in them.
We can refactor them of course.

Regarding final modifiers:
The checkstyle is checking for redundant final modifiers that
are really redundant, i.e. done on effectively final fields, e.g.
it catches things like:
```
- try (OutputStream os = myURLConnection.getOutputStream()) {
+ try (final OutputStream os = myURLConnection.getOutputStream()) {
      os.write(dynamoDBJSON.getBytes(StandardCharsets.US_ASCII));
  }
```
but it lets go things like:

```
private static String preparePayload(final EngineData engineData, final Date date) {
...
```

If the dependency is problematic or tedious to vet, we can probably quote the license
header on use just the checkstyle.xml from the project [1].

This commit also suppresses Unchecked cast on two places and removes a trailing space...

[1] https://github.com/wildfly/wildfly-checkstyle-config

Signed-off-by: Michal Karm Babacek <karm@fedoraproject.org>