### PR TITLE
Allow dash in artifactId.  Fixes 79

### DIFF
--- a/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/MicroprofileServersAddon.java
+++ b/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/MicroprofileServersAddon.java
@@ -224,10 +224,10 @@ public class MicroprofileServersAddon extends AbstractAddon {
             String rootJava = MavenCreator.SRC_MAIN_JAVA + "/" + directoryCreator.createPathForGroupAndArtifact(model.getMaven());
             String viewDirectory = model.getDirectory() + "/" + rootJava;
 
-            String artifactId = variables.get("artifact");
+            String application = variables.get("application");
 
             String javaFile = thymeleafEngine.processFile("RestApplication.java", alternatives, variables);
-            fileCreator.writeContents(viewDirectory, artifactId + "RestApplication.java", javaFile);
+            fileCreator.writeContents(viewDirectory, application + "RestApplication.java", javaFile);
 
         }
 
@@ -288,10 +288,10 @@ public class MicroprofileServersAddon extends AbstractAddon {
             processTemplateFile(resourcesDirectory, "logging.properties", alternatives, variables);
             processTemplateFile(resourcesDirectory, "publicKey.pem", alternatives, variables);
 
-            String artifactId = variables.get("artifact");
+            String application = variables.get("application");
 
             String restAppFile = thymeleafEngine.processFile("RestApplication.java", alternatives, variables);
-            fileCreator.writeContents(viewDirectory, artifactId + "RestApplication.java", restAppFile);
+            fileCreator.writeContents(viewDirectory, application + "RestApplication.java", restAppFile);
         }
 
         String rootJava = getJavaApplicationRootPackage(model);

--- a/src/main/java/org/eclipse/microprofile/starter/core/TemplateVariableProvider.java
+++ b/src/main/java/org/eclipse/microprofile/starter/core/TemplateVariableProvider.java
@@ -38,11 +38,12 @@ public class TemplateVariableProvider {
     public Map<String, String> determineVariables(JessieModel model) {
         Map<String, String> result = new HashMap<>();
 
-        result.put("java_package", model.getMaven().getGroupId() + '.' + model.getMaven().getArtifactId());
+        result.put("java_package", model.getMaven().getGroupId() + '.' + model.getMaven().getPackage());
         result.put("maven_artifactid", model.getMaven().getArtifactId());
 
         String artifactId = model.getMaven().getArtifactId().replaceAll("\\.", "");
         result.put("artifact", StringUtils.capitalize(artifactId));
+        result.put("application", StringUtils.capitalize(artifactId.replaceAll("-", "")));
 
         result.put("mp_version", model.getSpecification().getMicroProfileVersion().getCode());
 

--- a/src/main/java/org/eclipse/microprofile/starter/core/artifacts/DirectoryCreator.java
+++ b/src/main/java/org/eclipse/microprofile/starter/core/artifacts/DirectoryCreator.java
@@ -35,7 +35,7 @@ public abstract class DirectoryCreator {
     public abstract void removeDirectory(String directoryPath);
 
     public String createPathForGroupAndArtifact(JessieMaven mavenModel) {
-        return (mavenModel.getGroupId() + '.' + mavenModel.getArtifactId()).replaceAll("\\.", "/");
+        return (mavenModel.getGroupId() + '.' + mavenModel.getPackage()).replaceAll("\\.", "/");
     }
 
 }

--- a/src/main/java/org/eclipse/microprofile/starter/core/artifacts/JavaCreator.java
+++ b/src/main/java/org/eclipse/microprofile/starter/core/artifacts/JavaCreator.java
@@ -42,9 +42,9 @@ public class JavaCreator extends AbstractCreator {
         String viewDirectory = model.getDirectory() + "/" + rootJava;
         directoryCreator.createDirectory(viewDirectory);
 
-        String artifactId = variables.get("artifact");
+        String application = variables.get("application");
         String javaFile = thymeleafEngine.processFile("RestApplication.java", alternatives, variables);
-        fileCreator.writeContents(viewDirectory, artifactId + "RestApplication.java", javaFile);
+        fileCreator.writeContents(viewDirectory, application + "RestApplication.java", javaFile);
 
         javaFile = thymeleafEngine.processFile("HelloController.java", alternatives, variables);
         fileCreator.writeContents(viewDirectory, "HelloController.java", javaFile);

--- a/src/main/java/org/eclipse/microprofile/starter/core/model/JessieMaven.java
+++ b/src/main/java/org/eclipse/microprofile/starter/core/model/JessieMaven.java
@@ -49,4 +49,8 @@ public class JessieMaven {
         this.artifactId = artifactId;
     }
 
+    public String getPackage() {
+        return artifactId.replaceAll("-", ".");
+    }
+
 }

--- a/src/main/java/org/eclipse/microprofile/starter/validation/PackageValidator.java
+++ b/src/main/java/org/eclipse/microprofile/starter/validation/PackageValidator.java
@@ -41,7 +41,8 @@ public class PackageValidator implements Validator {
     public void validate(FacesContext facesContext, UIComponent uiComponent, Object value) throws ValidatorException {
 
         PackageNameValidator validator = retrieveInstance(PackageNameValidator.class);
-        if (!validator.isValidPackageName(value.toString())) {
+        String name = value.toString().replaceAll("-", ".");
+        if (!validator.isValidPackageName(name)) {
             FacesMessage msg =
                     new FacesMessage("Field validation failed.",
                             "Please provide a valid package name");

--- a/src/main/resources/files/RestApplication.java.tpl
+++ b/src/main/resources/files/RestApplication.java.tpl
@@ -15,5 +15,5 @@ import javax.ws.rs.core.Application;
 @LoginConfig(authMethod = "MP-JWT", realmName = "jwt-jaspi")
 @DeclareRoles({"protected"})
 [/]
-public class [# th:text="${artifact}"/]RestApplication extends Application {
+public class [# th:text="${application}"/]RestApplication extends Application {
 }

--- a/src/main/resources/files/helidon/RestApplication.java.tpl
+++ b/src/main/resources/files/helidon/RestApplication.java.tpl
@@ -30,7 +30,7 @@ import java.util.Set;
 @DeclareRoles({"protected"})
 [/]
 @ApplicationScoped
-public class [# th:text="${artifact}"/]RestApplication extends Application {
+public class [# th:text="${application}"/]RestApplication extends Application {
 
     @Override
     public Set<Class<?>> getClasses() {

--- a/src/main/resources/files/kumuluzEE/RestApplication.java.tpl
+++ b/src/main/resources/files/kumuluzEE/RestApplication.java.tpl
@@ -31,7 +31,7 @@ import java.util.Set;
 @LoginConfig(authMethod = "MP-JWT")
 @DeclareRoles({"protected"})
 [/]
-public class [# th:text="${artifact}"/]RestApplication extends Application {
+public class [# th:text="${application}"/]RestApplication extends Application {
 
     @Override
     public Set<Class<?>> getClasses() {

--- a/src/main/resources/files/payara-micro/RestApplication.java.tpl
+++ b/src/main/resources/files/payara-micro/RestApplication.java.tpl
@@ -18,5 +18,5 @@ import javax.ws.rs.core.Application;
 @LoginConfig(authMethod = "MP-JWT")
 @DeclareRoles({"protected"})
 [/]
-public class [# th:text="${artifact}"/]RestApplication extends Application {
+public class [# th:text="${application}"/]RestApplication extends Application {
 }

--- a/src/main/webapp/index.xhtml
+++ b/src/main/webapp/index.xhtml
@@ -77,7 +77,7 @@
                         </p:inputText>
 
                         <p:inputText id="artifactId" value="#{generatorDataBean.engineData.mavenData.artifactId}" required="true"
-                                     title="Used as part of the package name so it must comply with the Java rules"
+                                     title="Used as part of the package name so it must comply with the Java rules.  Hyphen is converted to . in package name"
                                      pt:autocomplete="off">
                             <f:validator validatorId="packageNameValidator"/>
                         </p:inputText></p:panelGrid>

--- a/src/test/java/org/eclipse/microprofile/starter/core/TemplateVariableProviderTest.java
+++ b/src/test/java/org/eclipse/microprofile/starter/core/TemplateVariableProviderTest.java
@@ -1,0 +1,29 @@
+package org.eclipse.microprofile.starter.core;
+
+import org.eclipse.microprofile.starter.core.model.JessieMaven;
+import org.eclipse.microprofile.starter.core.model.JessieModel;
+import org.eclipse.microprofile.starter.core.model.JessieSpecification;
+import org.eclipse.microprofile.starter.core.model.MicroProfileVersion;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Map;
+
+public class TemplateVariableProviderTest {
+
+    @Test
+    public void shouldStoreValidApplicationName() {
+        TemplateVariableProvider provider = new TemplateVariableProvider();
+        JessieModel model = new JessieModel();
+        JessieMaven maven = new JessieMaven();
+        JessieSpecification specification = new JessieSpecification();
+        specification.setMicroProfileVersion(MicroProfileVersion.MP22);
+        maven.setArtifactId("demo-service");
+        model.setMaven(maven);
+        model.setSpecification(specification);
+
+        Map<String, String> variables = provider.determineVariables(model);
+
+        Assert.assertEquals("Demoservice", variables.get("application"));
+    }
+}

--- a/src/test/java/org/eclipse/microprofile/starter/core/artifacts/DirectoryCreatorTest.java
+++ b/src/test/java/org/eclipse/microprofile/starter/core/artifacts/DirectoryCreatorTest.java
@@ -1,0 +1,21 @@
+package org.eclipse.microprofile.starter.core.artifacts;
+
+import org.eclipse.microprofile.starter.FakeDirectoryCreator;
+import org.eclipse.microprofile.starter.core.model.JessieMaven;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DirectoryCreatorTest {
+
+    @Test
+    public void shouldCreateUsingValidPackage() {
+        FakeDirectoryCreator creator = new FakeDirectoryCreator();
+
+        JessieMaven maven = new JessieMaven();
+        maven.setGroupId("com.test");
+        maven.setArtifactId(("test-service"));
+        String path = creator.createPathForGroupAndArtifact(maven);
+
+        Assert.assertEquals("com/test/test/service", path);
+    }
+}

--- a/src/test/java/org/eclipse/microprofile/starter/core/model/JessieMavenTest.java
+++ b/src/test/java/org/eclipse/microprofile/starter/core/model/JessieMavenTest.java
@@ -1,0 +1,16 @@
+package org.eclipse.microprofile.starter.core.model;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class JessieMavenTest {
+
+    @Test
+    public void shouldRelaceHypendsWithPeriodInPackageName() {
+        JessieMaven maven = new JessieMaven();
+
+        maven.setArtifactId("test-service");
+
+        Assert.assertEquals("test.service", maven.getPackage());
+    }
+}


### PR DESCRIPTION
I've changed to allow - within the artifactId.  The - is then changed to a . within the package structure.


Within templates, the - is removed from package names.

Signed-off-by: David Salter <davidmsalter@icloud.com>