### PR TITLE
Eliminate absolute path from OpenLiberty server.xml

### DIFF
--- a/src/main/resources/files/liberty/server.xml.tpl
+++ b/src/main/resources/files/liberty/server.xml.tpl
@@ -9,7 +9,7 @@
                   httpPort="${httpPort}"
                   httpsPort="${httpsPort}"/>
 
-    <application location="${project.build.directory}/${project.build.finalName}.war"/>
+    <application location="${project.build.finalName}.war"/>
 
     <logging traceSpecification="${log.name}.*=${log.level}"/>
 


### PR DESCRIPTION
WAR file will be put on apps directory by Liberty maven plugin, so Liberty server should use this file instead of WAR file on ${project.build.directory}. Maven 'package' goal will make single JAR file, and it may be used out of build server. Then it will fail because of absolute path setting in server.xml.

Signed-off-by: Takakiyo Tanaka <t.takakiy@gmail.com>
