### PR TITLE
REST API as documented on https://app.swaggerhub.com/apis/microprofile/starter/1

### DIFF
--- a/Container/start.sh
+++ b/Container/start.sh
@@ -13,6 +13,7 @@ java -server \
  -XX:+UseG1GC \
  -XX:+HeapDumpOnOutOfMemoryError \
  -XX:HeapDumpPath=/opt/mp-starter-hollow-thorntail/ \
+ -XX:+ExitOnOutOfMemoryError \
  -cp /opt/mp-starter-hollow-thorntail \
  org.wildfly.swarm.bootstrap.Main \
  /opt/mp-starter.war \

--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 [![Gitter](https://badges.gitter.im/eclipse/microprofile-starter.svg)](https://gitter.im/eclipse/microprofile-starter?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
+## Web
+
 Live tool at [MicroProfile starter - Generate MicroProfile Maven Project](https://start.microprofile.io/index.xhtml)
+
+## REST API
+
+See [documentation](./src/main/resources/REST-README.md).
 
 ## When can an implementation be added to the MicroProfile Tool
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
         <version.thorntail>2.2.1.Final</version.thorntail>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.exec.plugin.version>1.6.0</maven.exec.plugin.version>
 
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -206,6 +207,24 @@
                     </checkstyleRules>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>${maven.exec.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>generate-configs</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <executable>${basedir}/version.txt.sh</executable>
+                    <workingDirectory>${basedir}/target/classes/</workingDirectory>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -222,6 +241,12 @@
                     <groupId>io.thorntail</groupId>
                     <artifactId>cdi</artifactId>
                 </dependency>
+
+                <dependency>
+                    <groupId>io.thorntail</groupId>
+                    <artifactId>jaxrs</artifactId>
+                </dependency>
+
             </dependencies>
 
             <dependencyManagement>

--- a/src/main/java/org/eclipse/microprofile/starter/Version.java
+++ b/src/main/java/org/eclipse/microprofile/starter/Version.java
@@ -1,0 +1,34 @@
+package org.eclipse.microprofile.starter;
+
+import org.eclipse.microprofile.starter.core.files.FilesLocator;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import java.util.Scanner;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * @author Michal Karm Babacek <karm@redhat.com>
+ */
+@ApplicationScoped
+public class Version {
+    private static final Logger LOG = Logger.getLogger(Version.class.getName());
+
+    private String git;
+
+    @PostConstruct
+    public void init() {
+        try (Scanner s = new Scanner(FilesLocator.class.getClassLoader()
+                .getResourceAsStream("/version.txt")).useDelimiter("\\A")) {
+            git = s.hasNext() ? s.next() : "";
+        } catch (Exception e) {
+            LOG.log(Level.SEVERE, e.getMessage());
+        }
+    }
+
+    public String getGit() {
+        return git;
+    }
+}
+    

--- a/src/main/java/org/eclipse/microprofile/starter/Version.java
+++ b/src/main/java/org/eclipse/microprofile/starter/Version.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package org.eclipse.microprofile.starter;
 
 import org.eclipse.microprofile.starter.core.files.FilesLocator;

--- a/src/main/java/org/eclipse/microprofile/starter/core/validation/PackageNameValidator.java
+++ b/src/main/java/org/eclipse/microprofile/starter/core/validation/PackageNameValidator.java
@@ -29,10 +29,10 @@ import java.util.regex.Pattern;
 public class PackageNameValidator {
 
     public static final String VALID_REGEX = "^(?:\\w+|\\w+[\\.-]\\w+)+$";
-    public static final int MAX_LENGTH = 100;
+    public static final int MAX_LENGTH = 200;
     private Pattern pattern = Pattern.compile(VALID_REGEX, Pattern.CASE_INSENSITIVE);
 
     public boolean isValidPackageName(String name) {
-        return pattern.matcher(name).matches() && name.length() < MAX_LENGTH;
+        return name.length() < MAX_LENGTH && pattern.matcher(name).matches();
     }
 }

--- a/src/main/java/org/eclipse/microprofile/starter/core/validation/PackageNameValidator.java
+++ b/src/main/java/org/eclipse/microprofile/starter/core/validation/PackageNameValidator.java
@@ -23,17 +23,16 @@
 package org.eclipse.microprofile.starter.core.validation;
 
 import javax.enterprise.context.ApplicationScoped;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 @ApplicationScoped
 public class PackageNameValidator {
 
-    private static final String VALID_REGEX = "^(?:\\w+|\\w+\\.\\w+)+$";
+    public static final String VALID_REGEX = "^(?:\\w+|\\w+[\\.-]\\w+)+$";
+    public static final int MAX_LENGTH = 100;
+    private Pattern pattern = Pattern.compile(VALID_REGEX, Pattern.CASE_INSENSITIVE);
 
     public boolean isValidPackageName(String name) {
-        Pattern pattern = Pattern.compile(VALID_REGEX, Pattern.CASE_INSENSITIVE);
-        Matcher matcher = pattern.matcher(name);
-        return matcher.matches();
+        return pattern.matcher(name).matches() && name.length() < MAX_LENGTH;
     }
 }

--- a/src/main/java/org/eclipse/microprofile/starter/log/DynamoDBLogger.java
+++ b/src/main/java/org/eclipse/microprofile/starter/log/DynamoDBLogger.java
@@ -67,7 +67,7 @@ public class DynamoDBLogger {
     }
 
     private static byte[] signatureKey(
-            final String key, final String dateStamp, final String regionName, final String serviceName) 
+            final String key, final String dateStamp, final String regionName, final String serviceName)
             throws NoSuchAlgorithmException, InvalidKeyException {
         final byte[] kDate = sign(StandardCharsets.UTF_8.encode("AWS4" + key).array(), StandardCharsets.UTF_8.encode(dateStamp).array());
         final byte[] kRegion = sign(kDate, StandardCharsets.US_ASCII.encode(regionName).array());
@@ -86,8 +86,11 @@ public class DynamoDBLogger {
         }
         final String timestamp = logMessageTimeFormat.format(date);
         final String logmark = Stream.concat(
-                Stream.of(engineData.getMpVersion(), engineData.getSupportedServer(), engineData.getBeansxmlMode(), WEB_APP_INSTANCE_ID,
-                        timestamp, engineData.getMavenData().getArtifactId(), engineData.getMavenData().getGroupId()),
+                Stream.of(engineData.getMpVersion(), engineData.getSupportedServer(),
+                        engineData.getBeansxmlMode(), WEB_APP_INSTANCE_ID,
+                        timestamp, engineData.getMavenData().getArtifactId(),
+                        engineData.getMavenData().getGroupId(),
+                        engineData.getTrafficSource().toString()),
                 engineData.getSelectedSpecs().stream()
         ).collect(Collectors.joining());
         sha1Hash.update(logmark.getBytes());
@@ -119,6 +122,9 @@ public class DynamoDBLogger {
             s.append(String.join("\",\"", engineData.getSelectedSpecs()));
         }
         s.append("\"]},")
+                .append("\"trafficSource\":{\"S\":\"")
+                .append(engineData.getTrafficSource().toString())
+                .append("\"},")
                 .append("\"timestamp\":{\"S\":\"")
                 .append(timestamp)
                 .append("\"}}}");

--- a/src/main/java/org/eclipse/microprofile/starter/rest/API.java
+++ b/src/main/java/org/eclipse/microprofile/starter/rest/API.java
@@ -1,0 +1,11 @@
+package org.eclipse.microprofile.starter.rest;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+/**
+ * @author Michal Karm Babacek <karm@redhat.com>
+ */
+@ApplicationPath("/api")
+public class API extends Application {
+}

--- a/src/main/java/org/eclipse/microprofile/starter/rest/API.java
+++ b/src/main/java/org/eclipse/microprofile/starter/rest/API.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package org.eclipse.microprofile.starter.rest;
 
 import javax.ws.rs.ApplicationPath;

--- a/src/main/java/org/eclipse/microprofile/starter/rest/APIEndpoint.java
+++ b/src/main/java/org/eclipse/microprofile/starter/rest/APIEndpoint.java
@@ -1,0 +1,74 @@
+package org.eclipse.microprofile.starter.rest;
+
+import org.eclipse.microprofile.starter.addon.microprofile.servers.model.MicroprofileSpec;
+import org.eclipse.microprofile.starter.addon.microprofile.servers.model.SupportedServer;
+import org.eclipse.microprofile.starter.core.model.JavaSEVersion;
+import org.eclipse.microprofile.starter.core.model.MicroProfileVersion;
+import org.eclipse.microprofile.starter.rest.model.Project;
+
+import javax.inject.Inject;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+import java.util.List;
+
+/**
+ * @author Michal Karm Babacek <karm@redhat.com>
+ */
+@Path("/1.0.0")
+public class APIEndpoint {
+
+    @Inject
+    private APIService api;
+
+    @Path("/")
+    @GET
+    @Produces({"text/x-markdown"})
+    public Response readme(@HeaderParam(HttpHeaders.IF_NONE_MATCH) String ifNoneMatch) {
+        return api.readme(ifNoneMatch);
+    }
+
+    @Path("/mpVersion")
+    @GET
+    @Produces({"application/json"})
+    public Response listMPVersions() {
+        return api.listMPVersions();
+    }
+
+    @Path("/mpVersion/{mpVersion}")
+    @GET
+    @Produces({"application/json"})
+    public Response listOptions(@NotNull @PathParam("mpVersion") MicroProfileVersion mpVersion) {
+        return api.listOptions(mpVersion);
+    }
+
+
+    @Path("/project")
+    @GET
+    @Produces({"application/zip", "application/json"})
+    public Response getProject(@HeaderParam(HttpHeaders.IF_NONE_MATCH) String ifNoneMatch,
+                               @QueryParam("supportedServer") SupportedServer supportedServer,
+                               @QueryParam("groupId") String groupId,
+                               @QueryParam("artifactId") String artifactId,
+                               @QueryParam("mpVersion") MicroProfileVersion mpVersion,
+                               @QueryParam("javaSEVersion") JavaSEVersion javaSEVersion,
+                               @QueryParam("selectedSpecs") List<MicroprofileSpec> selectedSpecs) {
+        return api.getProject(ifNoneMatch, supportedServer, groupId, artifactId, mpVersion, javaSEVersion, selectedSpecs);
+    }
+
+    @Path("/project")
+    @POST
+    @Consumes({"application/json"})
+    @Produces({"application/zip", "application/json"})
+    public Response projectPost(@HeaderParam(HttpHeaders.IF_NONE_MATCH) String ifNoneMatch, @NotNull Project body) {
+        return api.getProject(ifNoneMatch, body);
+    }
+}

--- a/src/main/java/org/eclipse/microprofile/starter/rest/APIEndpoint.java
+++ b/src/main/java/org/eclipse/microprofile/starter/rest/APIEndpoint.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package org.eclipse.microprofile.starter.rest;
 
 import org.eclipse.microprofile.starter.addon.microprofile.servers.model.MicroprofileSpec;

--- a/src/main/java/org/eclipse/microprofile/starter/rest/APIEndpointLatest.java
+++ b/src/main/java/org/eclipse/microprofile/starter/rest/APIEndpointLatest.java
@@ -42,8 +42,8 @@ import java.util.List;
 /**
  * @author Michal Karm Babacek <karm@redhat.com>
  */
-@Path("/1.0.0")
-public class APIEndpoint {
+@Path("/")
+public class APIEndpointLatest {
 
     @Inject
     private APIService api;

--- a/src/main/java/org/eclipse/microprofile/starter/rest/APIEndpointV1.java
+++ b/src/main/java/org/eclipse/microprofile/starter/rest/APIEndpointV1.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.eclipse.microprofile.starter.rest;
+
+import javax.ws.rs.Path;
+
+/**
+ * @author Michal Karm Babacek <karm@redhat.com>
+ */
+@Path("/1")
+public class APIEndpointV1 extends APIEndpointLatest {
+}

--- a/src/main/java/org/eclipse/microprofile/starter/rest/APIService.java
+++ b/src/main/java/org/eclipse/microprofile/starter/rest/APIService.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package org.eclipse.microprofile.starter.rest;
 
 import org.apache.commons.lang3.StringUtils;

--- a/src/main/java/org/eclipse/microprofile/starter/rest/APIService.java
+++ b/src/main/java/org/eclipse/microprofile/starter/rest/APIService.java
@@ -102,13 +102,15 @@ public class APIService {
     public static final String ERROR001 =
             "{\"error\":\"supportedServer query parameter is mandatory\",\"code\":\"ERROR001\"}";
     public static final String ERROR002 =
-            "{\"error\":\"Selected supportedServer is not available for given mpVersion\",\"code\":\"ERROR002\"}";
+            "{\"error\":\"Selected supportedServer is not available for the given mpVersion\",\"code\":\"ERROR002\"}";
     public static final String ERROR003 =
-            "{\"error\":\"One or more selectedSpecs is not available for given mpVersion\",\"code\":\"ERROR003\"}";
+            "{\"error\":\"One or more selectedSpecs is not available for the given mpVersion\",\"code\":\"ERROR003\"}";
     public static final String ERROR004 =
-            "{\"error\":\"groupId contains illegal characters, does not start with a word or is longer than " + PackageNameValidator.MAX_LENGTH + "\",\"code\":\"ERROR004\"}";
+            "{\"error\":\"groupId contains illegal characters, does not start with a word or is longer than " +
+                    PackageNameValidator.MAX_LENGTH + "\",\"code\":\"ERROR004\"}";
     public static final String ERROR005 =
-            "{\"error\":\"artifactId contains illegal characters, does not start with a word or is longer than " + PackageNameValidator.MAX_LENGTH + "\",\"code\":\"ERROR005\"}";
+            "{\"error\":\"artifactId contains illegal characters, does not start with a word or is longer than " +
+                    PackageNameValidator.MAX_LENGTH + "\",\"code\":\"ERROR005\"}";
 
     @Inject
     private ModelManager modelManager;

--- a/src/main/java/org/eclipse/microprofile/starter/rest/APIService.java
+++ b/src/main/java/org/eclipse/microprofile/starter/rest/APIService.java
@@ -1,0 +1,251 @@
+package org.eclipse.microprofile.starter.rest;
+
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.microprofile.starter.Version;
+import org.eclipse.microprofile.starter.ZipFileCreator;
+import org.eclipse.microprofile.starter.addon.microprofile.servers.model.MicroprofileSpec;
+import org.eclipse.microprofile.starter.addon.microprofile.servers.model.SupportedServer;
+import org.eclipse.microprofile.starter.core.artifacts.Creator;
+import org.eclipse.microprofile.starter.core.files.FilesLocator;
+import org.eclipse.microprofile.starter.core.model.BeansXMLMode;
+import org.eclipse.microprofile.starter.core.model.JavaSEVersion;
+import org.eclipse.microprofile.starter.core.model.JessieMaven;
+import org.eclipse.microprofile.starter.core.model.JessieModel;
+import org.eclipse.microprofile.starter.core.model.JessieSpecification;
+import org.eclipse.microprofile.starter.core.model.MicroProfileVersion;
+import org.eclipse.microprofile.starter.core.model.ModelManager;
+import org.eclipse.microprofile.starter.core.model.OptionValue;
+import org.eclipse.microprofile.starter.log.LoggingTask;
+import org.eclipse.microprofile.starter.rest.model.MPOptionsAvailable;
+import org.eclipse.microprofile.starter.rest.model.Project;
+import org.eclipse.microprofile.starter.view.EngineData;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.Resource;
+import javax.enterprise.concurrent.ManagedExecutorService;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.core.EntityTag;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Scanner;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * @author Michal Karm Babacek <karm@redhat.com>
+ */
+@ApplicationScoped
+public class APIService {
+
+    private static final Logger LOG = Logger.getLogger(APIService.class.getName());
+
+    private Map<MicroProfileVersion, MPOptionsAvailable> mpvToOptions;
+
+    private String readme;
+    private EntityTag readmeEtag;
+
+    @Inject
+    private Version version;
+
+    @PostConstruct
+    public void init() {
+        mpvToOptions =
+                new HashMap<MicroProfileVersion, MPOptionsAvailable>(MicroProfileVersion.values().length) {
+                    {
+                        Stream.of(MicroProfileVersion.values()).forEach(mpv -> put(mpv, new MPOptionsAvailable(
+                                Stream.of(SupportedServer.values())
+                                        .filter(v -> v.getMpVersions().contains(mpv)).collect(Collectors.toList()),
+                                Stream.of(MicroprofileSpec.values())
+                                        .filter(v -> v.getMpVersions().contains(mpv)).collect(Collectors.toList()))));
+
+                    }
+
+                };
+        try (Scanner s = new Scanner(FilesLocator.class.getClassLoader()
+                .getResourceAsStream("/REST-README.md")).useDelimiter("\\A")) {
+            readme = (s.hasNext() ? s.next() : "") + "\n" + version.getGit() + "\n";
+            readmeEtag = new EntityTag(Integer.toHexString(readme.hashCode()));
+        } catch (Exception e) {
+            LOG.log(Level.SEVERE, e.getMessage());
+        }
+    }
+
+    public static final String ERROR001 = "{\"error\":\"supportedServer query parameter is mandatory\",\"code\":\"ERROR001\"}";
+    public static final String ERROR002 = "{\"error\":\"Selected supportedServer is not available for given mpVersion\",\"code\":\"ERROR002\"}";
+    public static final String ERROR003 = "{\"error\":\"One or more selectedSpecs is not available for given mpVersion\",\"code\":\"ERROR003\"}";
+
+    @Inject
+    private ModelManager modelManager;
+
+    @Inject
+    private Creator creator;
+
+    @Inject
+    private ZipFileCreator zipFileCreator;
+
+    @Resource
+    private ManagedExecutorService managedExecutorService;
+
+    public Response readme(String ifNoneMatch) {
+        if (ifNoneMatch != null) {
+            if (readmeEtag.toString().equals(ifNoneMatch)) {
+                return Response.notModified().build();
+            }
+        }
+        return Response.ok(readme).build();
+    }
+
+    public Response listMPVersions() {
+        return Response.ok(
+                // We don't want to return NONE as a viable option
+                Stream.of(MicroProfileVersion.values())
+                        .filter(mpv -> mpv != MicroProfileVersion.NONE)
+                        .collect(Collectors.toList()), MediaType.APPLICATION_JSON_TYPE
+        ).build();
+    }
+
+    public Response listOptions(MicroProfileVersion mpVersion) {
+        return Response.ok(mpvToOptions.get(mpVersion)).build();
+    }
+
+    public Response getProject(String ifNoneMatch,
+                               SupportedServer supportedServer,
+                               String groupId, String artifactId,
+                               MicroProfileVersion mpVersion,
+                               JavaSEVersion javaSEVersion,
+                               List<MicroprofileSpec> selectedSpecs) {
+        Project project = new Project();
+        project.setSupportedServer(supportedServer);
+        project.setGroupId(groupId);
+        project.setArtifactId(artifactId);
+        project.setMpVersion(mpVersion);
+        project.setJavaSEVersion(javaSEVersion);
+        project.setSelectedSpecs(selectedSpecs);
+        return processProject(ifNoneMatch, project);
+    }
+
+    public Response getProject(String ifNoneMatch, Project body) {
+        return processProject(ifNoneMatch, body);
+    }
+
+    private Response validate(@NotNull Project p) {
+        if (p.getSupportedServer() == null) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(ERROR001)
+                    .type("application/json")
+                    .header("Content-Length", ERROR001.length())
+                    .header("Content-Disposition", "attachment; filename=\"error.json\"")
+                    .build();
+        }
+        if (StringUtils.isBlank(p.getGroupId())) {
+            p.setGroupId(EngineData.DEFAULT_GROUP_ID);
+        }
+        if (StringUtils.isBlank(p.getArtifactId())) {
+            p.setArtifactId(EngineData.DEFAULT_ARTIFACT_ID);
+        }
+        if (p.getMpVersion() == null || p.getMpVersion() == MicroProfileVersion.NONE) {
+            p.setMpVersion(
+                    p.getSupportedServer().getMpVersions().get(p.getSupportedServer().getMpVersions().size() - 1));
+        }
+        if (!mpvToOptions.get(p.getMpVersion()).getSupportedServers().contains(p.getSupportedServer())) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .type("application/json")
+                    .header("Content-Length", ERROR002.length())
+                    .header("Content-Disposition", "attachment; filename=\"error.json\"")
+                    .entity(ERROR002)
+                    .build();
+        }
+        if (p.getJavaSEVersion() == null || p.getJavaSEVersion() == JavaSEVersion.NONE) {
+            p.setJavaSEVersion(EngineData.DEFAULT_JAVA_SE_VERSION);
+        }
+        if (p.getSelectedSpecs() == null || p.getSelectedSpecs().isEmpty()) {
+            p.setSelectedSpecs(mpvToOptions.get(p.getMpVersion()).getSpecs());
+        }
+        if (!mpvToOptions.get(p.getMpVersion()).getSpecs().containsAll(p.getSelectedSpecs())) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .type("application/json")
+                    .header("Content-Length", ERROR003.length())
+                    .header("Content-Disposition", "attachment; filename=\"error.json\"")
+                    .entity(ERROR003)
+                    .build();
+        }
+
+        return Response.ok().build();
+    }
+
+    private EngineData getEngineData(Project p) {
+        List<String> selectedSpecs = p.getSelectedSpecs().stream()
+                .map(MicroprofileSpec::getCode).collect(Collectors.toList());
+        EngineData engineData = new EngineData();
+        engineData.getMavenData().setGroupId(p.getGroupId());
+        engineData.getMavenData().setArtifactId(p.getArtifactId());
+        engineData.setTrafficSource(EngineData.TrafficSource.REST);
+        engineData.setSelectedSpecs(selectedSpecs);
+        engineData.setSupportedServer(p.getSupportedServer().getCode());
+        engineData.setMpVersion(p.getMpVersion().getCode());
+        return engineData;
+    }
+
+    private Response processProject(String ifNoneMatch, @NotNull Project p) {
+
+        Response validatorResponse = validate(p);
+        if (validatorResponse.getStatusInfo() != Response.Status.OK) {
+            return validatorResponse;
+        }
+
+        EngineData ed = getEngineData(p);
+
+        managedExecutorService.submit(new LoggingTask(ed));
+
+        EntityTag etag = new EntityTag(Integer.toHexString(31 * version.getGit().hashCode() + p.hashCode()));
+
+        if (ifNoneMatch != null) {
+            if (etag.toString().equals(ifNoneMatch)) {
+                return Response.notModified().build();
+            }
+        }
+
+        JessieModel model = new JessieModel();
+        model.setDirectory(ed.getMavenData().getArtifactId());
+
+        JessieMaven mavenModel = new JessieMaven();
+        mavenModel.setGroupId(ed.getMavenData().getGroupId());
+        mavenModel.setArtifactId(ed.getMavenData().getArtifactId());
+        model.setMaven(mavenModel);
+
+        JessieSpecification specifications = new JessieSpecification();
+        specifications.setJavaSEVersion(p.getJavaSEVersion());
+        specifications.setMicroProfileVersion(p.getMpVersion());
+
+        model.getOptions().put("mp.server", new OptionValue(ed.getSupportedServer()));
+        model.getOptions().put("mp.specs", new OptionValue(ed.getSelectedSpecs()));
+
+        model.setSpecification(specifications);
+
+        model.getOptions().put(BeansXMLMode.OptionName.NAME,
+                new OptionValue(BeansXMLMode.getValue(ed.getBeansxmlMode()).getMode()));
+
+        modelManager.prepareModel(model, false);
+        creator.createArtifacts(model);
+
+        byte[] archive = zipFileCreator.createArchive();
+
+        String fileName = ed.getMavenData().getArtifactId() + ".zip";
+
+        return Response
+                .ok()
+                .tag(etag)
+                .header("Content-Length", archive.length)
+                .header("Content-Disposition", "attachment; filename=\"" + fileName + "\"")
+                .type("application/zip")
+                .entity(archive)
+                .build();
+    }
+}

--- a/src/main/java/org/eclipse/microprofile/starter/rest/APIService.java
+++ b/src/main/java/org/eclipse/microprofile/starter/rest/APIService.java
@@ -87,9 +87,9 @@ public class APIService {
     public static final String ERROR003 =
             "{\"error\":\"One or more selectedSpecs is not available for given mpVersion\",\"code\":\"ERROR003\"}";
     public static final String ERROR004 =
-            "{\"error\":\"groupId contains illegal characters or is longer than " + PackageNameValidator.MAX_LENGTH + "\",\"code\":\"ERROR004\"}";
+            "{\"error\":\"groupId contains illegal characters, does not start with a word or is longer than " + PackageNameValidator.MAX_LENGTH + "\",\"code\":\"ERROR004\"}";
     public static final String ERROR005 =
-            "{\"error\":\"artifactId contains illegal characters or is longer than " + PackageNameValidator.MAX_LENGTH + "\",\"code\":\"ERROR005\"}";
+            "{\"error\":\"artifactId contains illegal characters, does not start with a word or is longer than " + PackageNameValidator.MAX_LENGTH + "\",\"code\":\"ERROR005\"}";
 
     @Inject
     private ModelManager modelManager;

--- a/src/main/java/org/eclipse/microprofile/starter/rest/model/MPOptionsAvailable.java
+++ b/src/main/java/org/eclipse/microprofile/starter/rest/model/MPOptionsAvailable.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package org.eclipse.microprofile.starter.rest.model;
 
 import org.eclipse.microprofile.starter.addon.microprofile.servers.model.MicroprofileSpec;

--- a/src/main/java/org/eclipse/microprofile/starter/rest/model/MPOptionsAvailable.java
+++ b/src/main/java/org/eclipse/microprofile/starter/rest/model/MPOptionsAvailable.java
@@ -1,0 +1,27 @@
+package org.eclipse.microprofile.starter.rest.model;
+
+import org.eclipse.microprofile.starter.addon.microprofile.servers.model.MicroprofileSpec;
+import org.eclipse.microprofile.starter.addon.microprofile.servers.model.SupportedServer;
+
+import java.util.Collections;
+import java.util.List;
+
+public class MPOptionsAvailable {
+
+    private final List<SupportedServer> supportedServers;
+    private final List<MicroprofileSpec> specs;
+
+    public MPOptionsAvailable(List<SupportedServer> supportedServers, List<MicroprofileSpec> specs) {
+        this.supportedServers = supportedServers;
+        this.specs = specs;
+    }
+
+    public List<SupportedServer> getSupportedServers() {
+        Collections.shuffle(supportedServers);
+        return supportedServers;
+    }
+
+    public List<MicroprofileSpec> getSpecs() {
+        return specs;
+    }
+}

--- a/src/main/java/org/eclipse/microprofile/starter/rest/model/Project.java
+++ b/src/main/java/org/eclipse/microprofile/starter/rest/model/Project.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package org.eclipse.microprofile.starter.rest.model;
 
 import org.eclipse.microprofile.starter.addon.microprofile.servers.model.MicroprofileSpec;

--- a/src/main/java/org/eclipse/microprofile/starter/rest/model/Project.java
+++ b/src/main/java/org/eclipse/microprofile/starter/rest/model/Project.java
@@ -5,8 +5,6 @@ import org.eclipse.microprofile.starter.addon.microprofile.servers.model.Support
 import org.eclipse.microprofile.starter.core.model.JavaSEVersion;
 import org.eclipse.microprofile.starter.core.model.MicroProfileVersion;
 
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Pattern;
 import java.util.List;
 import java.util.Objects;
 
@@ -19,7 +17,6 @@ public class Project {
     private SupportedServer supportedServer = null;
     private List<MicroprofileSpec> selectedSpecs = null;
 
-    @Pattern(regexp = "^(\\w+|\\w+\\.\\w+)+$")
     public String getGroupId() {
         return groupId;
     }
@@ -28,7 +25,6 @@ public class Project {
         this.groupId = groupId;
     }
 
-    @Pattern(regexp = "^(\\w+|\\w+\\.\\w+)+$")
     public String getArtifactId() {
         return artifactId;
     }
@@ -53,7 +49,6 @@ public class Project {
         this.javaSEVersion = javaSEVersion;
     }
 
-    @NotNull
     public SupportedServer getSupportedServer() {
         return supportedServer;
     }

--- a/src/main/java/org/eclipse/microprofile/starter/rest/model/Project.java
+++ b/src/main/java/org/eclipse/microprofile/starter/rest/model/Project.java
@@ -1,0 +1,94 @@
+package org.eclipse.microprofile.starter.rest.model;
+
+import org.eclipse.microprofile.starter.addon.microprofile.servers.model.MicroprofileSpec;
+import org.eclipse.microprofile.starter.addon.microprofile.servers.model.SupportedServer;
+import org.eclipse.microprofile.starter.core.model.JavaSEVersion;
+import org.eclipse.microprofile.starter.core.model.MicroProfileVersion;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import java.util.List;
+import java.util.Objects;
+
+
+public class Project {
+    private String groupId = null;
+    private String artifactId = null;
+    private MicroProfileVersion mpVersion = null;
+    private JavaSEVersion javaSEVersion = null;
+    private SupportedServer supportedServer = null;
+    private List<MicroprofileSpec> selectedSpecs = null;
+
+    @Pattern(regexp = "^(\\w+|\\w+\\.\\w+)+$")
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public void setGroupId(String groupId) {
+        this.groupId = groupId;
+    }
+
+    @Pattern(regexp = "^(\\w+|\\w+\\.\\w+)+$")
+    public String getArtifactId() {
+        return artifactId;
+    }
+
+    public void setArtifactId(String artifactId) {
+        this.artifactId = artifactId;
+    }
+
+    public MicroProfileVersion getMpVersion() {
+        return mpVersion;
+    }
+
+    public void setMpVersion(MicroProfileVersion mpVersion) {
+        this.mpVersion = mpVersion;
+    }
+
+    public JavaSEVersion getJavaSEVersion() {
+        return javaSEVersion;
+    }
+
+    public void setJavaSEVersion(JavaSEVersion javaSEVersion) {
+        this.javaSEVersion = javaSEVersion;
+    }
+
+    @NotNull
+    public SupportedServer getSupportedServer() {
+        return supportedServer;
+    }
+
+    public void setSupportedServer(SupportedServer supportedServer) {
+        this.supportedServer = supportedServer;
+    }
+
+    public List<MicroprofileSpec> getSelectedSpecs() {
+        return selectedSpecs;
+    }
+
+    public void setSelectedSpecs(List<MicroprofileSpec> selectedSpecs) {
+        this.selectedSpecs = selectedSpecs;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Project project = (Project) o;
+        return Objects.equals(groupId, project.groupId) &&
+                Objects.equals(artifactId, project.artifactId) &&
+                mpVersion == project.mpVersion &&
+                javaSEVersion == project.javaSEVersion &&
+                supportedServer == project.supportedServer &&
+                Objects.equals(selectedSpecs, project.selectedSpecs);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(groupId, artifactId, mpVersion, javaSEVersion, supportedServer, selectedSpecs);
+    }
+}

--- a/src/main/java/org/eclipse/microprofile/starter/validation/PackageValidator.java
+++ b/src/main/java/org/eclipse/microprofile/starter/validation/PackageValidator.java
@@ -29,6 +29,7 @@ import javax.enterprise.inject.UnsatisfiedResolutionException;
 import javax.enterprise.inject.spi.CDI;
 import javax.faces.application.FacesMessage;
 import javax.faces.component.UIComponent;
+import javax.faces.component.html.HtmlInputText;
 import javax.faces.context.FacesContext;
 import javax.faces.validator.FacesValidator;
 import javax.faces.validator.Validator;
@@ -43,7 +44,7 @@ public class PackageValidator implements Validator {
         PackageNameValidator validator = retrieveInstance(PackageNameValidator.class);
         if (!validator.isValidPackageName(value.toString())) {
             FacesMessage msg =
-                    new FacesMessage(uiComponent.getId() + " field validation failed.",
+                    new FacesMessage(((HtmlInputText) uiComponent).getLabel() + " field validation failed.",
                             "Please provide a valid package name");
             msg.setSeverity(FacesMessage.SEVERITY_ERROR);
 

--- a/src/main/java/org/eclipse/microprofile/starter/validation/PackageValidator.java
+++ b/src/main/java/org/eclipse/microprofile/starter/validation/PackageValidator.java
@@ -41,10 +41,9 @@ public class PackageValidator implements Validator {
     public void validate(FacesContext facesContext, UIComponent uiComponent, Object value) throws ValidatorException {
 
         PackageNameValidator validator = retrieveInstance(PackageNameValidator.class);
-        String name = value.toString().replaceAll("-", ".");
-        if (!validator.isValidPackageName(name)) {
+        if (!validator.isValidPackageName(value.toString())) {
             FacesMessage msg =
-                    new FacesMessage("Field validation failed.",
+                    new FacesMessage(uiComponent.getId() + " field validation failed.",
                             "Please provide a valid package name");
             msg.setSeverity(FacesMessage.SEVERITY_ERROR);
 

--- a/src/main/java/org/eclipse/microprofile/starter/view/EngineData.java
+++ b/src/main/java/org/eclipse/microprofile/starter/view/EngineData.java
@@ -19,24 +19,36 @@
  */
 package org.eclipse.microprofile.starter.view;
 
+import org.eclipse.microprofile.starter.core.model.JavaSEVersion;
 import org.eclipse.microprofile.starter.core.model.JessieMaven;
 
 import java.util.List;
 
 public class EngineData {
 
+    public static final String DEFAULT_GROUP_ID = "com.example";
+    public static final String DEFAULT_ARTIFACT_ID = "demo";
+    public static final JavaSEVersion DEFAULT_JAVA_SE_VERSION = JavaSEVersion.SE8;
+
     private JessieMaven mavenData;
-    private String javaSEVersion = "1.8";
+    private String javaSEVersion = DEFAULT_JAVA_SE_VERSION.getCode();
 
     private String mpVersion;
     private String supportedServer;
     private String beansxmlMode = "all";
     private List<String> selectedSpecs;
 
+    private TrafficSource trafficSource = TrafficSource.WEB;
+
+    public enum TrafficSource {
+        WEB,
+        REST
+    }
+
     public EngineData() {
         mavenData = new JessieMaven();
-        mavenData.setGroupId("com.example");
-        mavenData.setArtifactId("demo");
+        mavenData.setGroupId(DEFAULT_GROUP_ID);
+        mavenData.setArtifactId(DEFAULT_ARTIFACT_ID);
     }
 
     public JessieMaven getMavenData() {
@@ -85,5 +97,13 @@ public class EngineData {
 
     public void setSelectedSpecs(List<String> selectedSpecs) {
         this.selectedSpecs = selectedSpecs;
+    }
+
+    public TrafficSource getTrafficSource() {
+        return trafficSource;
+    }
+
+    public void setTrafficSource(TrafficSource trafficSource) {
+        this.trafficSource = trafficSource;
     }
 }

--- a/src/main/java/org/eclipse/microprofile/starter/view/GeneratorDataBean.java
+++ b/src/main/java/org/eclipse/microprofile/starter/view/GeneratorDataBean.java
@@ -22,6 +22,7 @@
  */
 package org.eclipse.microprofile.starter.view;
 
+import org.eclipse.microprofile.starter.Version;
 import org.eclipse.microprofile.starter.ZipFileCreator;
 import org.eclipse.microprofile.starter.addon.microprofile.servers.model.MicroprofileSpec;
 import org.eclipse.microprofile.starter.addon.microprofile.servers.model.SupportedServer;
@@ -51,7 +52,11 @@ import javax.inject.Named;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Serializable;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -67,6 +72,9 @@ public class GeneratorDataBean implements Serializable {
 
     @Inject
     private ZipFileCreator zipFileCreator;
+
+    @Inject
+    private Version version;
 
     @Resource
     private ManagedExecutorService managedExecutorService;
@@ -186,6 +194,10 @@ public class GeneratorDataBean implements Serializable {
         // Important! Otherwise JSF will attempt to render the response which obviously will fail
         // since it's already written with a file and closed.
         fc.responseComplete();
+    }
+
+    public Version getVersion() {
+        return version;
     }
 
     public EngineData getEngineData() {

--- a/src/main/resources/REST-README.md
+++ b/src/main/resources/REST-README.md
@@ -15,7 +15,7 @@
 # Project generator REST API
 
 This document summarizes examples of MicroProfile Starter web application REST API
-[microprofile/starter/1.0.0](https://app.swaggerhub.com/apis/microprofile/starter/1.0.0)
+[microprofile/starter/1](https://app.swaggerhub.com/apis/microprofile/starter/1)
 
 Each MicroProfile version (mpVersion) offers a suite of specifications (specs) and is implemented
 by a set of application servers (supportedServers).
@@ -26,7 +26,7 @@ The latest mpVersion with all specs it offers is used by default then.
 # Get available MicroProfile versions
 
 ```
-$ curl https://start.microprofile.io/api/1.0.0/mpVersion
+$ curl https://start.microprofile.io/api/1/mpVersion
 
 ["MP22","MP21","MP20","MP14","MP13","MP12"]
 ```
@@ -37,7 +37,7 @@ Note the order of supportedServers values is pseudorandom each call.
 Note the JSON formatting was altered for this document.
 
 ```
-$ curl https://start.microprofile.io/api/1.0.0/mpVersion/MP14
+$ curl https://start.microprofile.io/api/1/mpVersion/MP14
 {
   "supportedServers": [
     "PAYARA_MICRO",
@@ -67,7 +67,7 @@ Curl: ```-O -J``` makes curl to save the zip file in the current directory. ```-
 Note that latest available MP version for the supportedServer and All available Specs were selected by default.
 
 ```
-$ curl -O -J 'https://start.microprofile.io/api/1.0.0/project?supportedServer=THORNTAIL_V2'
+$ curl -O -J 'https://start.microprofile.io/api/1/project?supportedServer=THORNTAIL_V2'
 
 curl: Saved to filename 'demo.zip'
 
@@ -79,7 +79,7 @@ The only mandatory attribute is ```supportedServer```. One can omit ```-v``` cur
 Note the optional usage of [Etag](https://tools.ietf.org/html/rfc7232#section-2.3) and [If-None-Match](https://tools.ietf.org/html/rfc7232#section-3.2).
 
 ```
-$ curl -v -O -J -L 'https://start.microprofile.io/api/1.0.0/project?supportedServer=PAYARA_MICRO&artifactId=XXXXX&mpVersion=MP12&selectedSpecs=FAULT_TOLERANCE&selectedSpecs=JWT_AUTH'
+$ curl -v -O -J -L 'https://start.microprofile.io/api/1/project?supportedServer=PAYARA_MICRO&artifactId=XXXXX&mpVersion=MP12&selectedSpecs=FAULT_TOLERANCE&selectedSpecs=JWT_AUTH'
 
 < ETag: "dd085c81"
 
@@ -89,7 +89,7 @@ curl: Saved to filename 'XXXXX.zip'
 Note we can use ETag dd085c81 from the previous response:
 
 ```
-curl -v -O -J -L -H 'If-None-Match: "dd085c81"' 'https://start.microprofile.io/api/1.0.0/project?supportedServer=PAYARA_MICRO&artifactId=XXXXX&mpVersion=MP12&selectedSpecs=FAULT_TOLERANCE&selectedSpecs=JWT_AUTH'
+curl -v -O -J -L -H 'If-None-Match: "dd085c81"' 'https://start.microprofile.io/api/1/project?supportedServer=PAYARA_MICRO&artifactId=XXXXX&mpVersion=MP12&selectedSpecs=FAULT_TOLERANCE&selectedSpecs=JWT_AUTH'
 
 < HTTP/1.1 304 Not Modified
 ```
@@ -97,7 +97,7 @@ curl -v -O -J -L -H 'If-None-Match: "dd085c81"' 'https://start.microprofile.io/a
 ## Example with all attributes
 
 ```
-$ curl -O -J -L 'https://start.microprofile.io/api/1.0.0/project?supportedServer=LIBERTY&groupId=com.example&artifactId=myapp&mpVersion=MP22&javaSEVersion=SE8&selectedSpecs=CONFIG&selectedSpecs=FAULT_TOLERANCE&selectedSpecs=JWT_AUTH&selectedSpecs=HEALTH_METRICS&selectedSpecs=HEALTH_CHECKS&selectedSpecs=OPEN_API&selectedSpecs=OPEN_TRACING&selectedSpecs=REST_CLIENT'
+$ curl -O -J -L 'https://start.microprofile.io/api/1/project?supportedServer=LIBERTY&groupId=com.example&artifactId=myapp&mpVersion=MP22&javaSEVersion=SE8&selectedSpecs=CONFIG&selectedSpecs=FAULT_TOLERANCE&selectedSpecs=JWT_AUTH&selectedSpecs=HEALTH_METRICS&selectedSpecs=HEALTH_CHECKS&selectedSpecs=OPEN_API&selectedSpecs=OPEN_TRACING&selectedSpecs=REST_CLIENT'
 
 curl: Saved to filename 'myapp.zip'
 ```
@@ -107,7 +107,7 @@ curl: Saved to filename 'myapp.zip'
 By POSTing a JSON string one can get the same result as with using query parameters above.
 
 ```
-$ curl -O -J -L -H "Content-Type: application/json" -d '{"mpVersion":"MP14","supportedServer":"TOMEE","selectedSpecs":["REST_CLIENT","CONFIG"]}' 'https://start.microprofile.io/api/1.0.0/project'
+$ curl -O -J -L -H "Content-Type: application/json" -d '{"mpVersion":"MP14","supportedServer":"TOMEE","selectedSpecs":["REST_CLIENT","CONFIG"]}' 'https://start.microprofile.io/api/1/project'
 
 curl: Saved to filename 'demo.zip'
 ```
@@ -115,7 +115,7 @@ curl: Saved to filename 'demo.zip'
 This is how one can have the JSON stored in a file:
 
 ```
-$ curl -O -J -L -H "Content-Type: application/json" -d @my.json 'https://start.microprofile.io/api/1.0.0/project'
+$ curl -O -J -L -H "Content-Type: application/json" -d @my.json 'https://start.microprofile.io/api/1/project'
 
 curl: Saved to filename 'demo.zip'
 ```
@@ -142,7 +142,7 @@ $ cat all.json
   ]
 }
 
-$ curl -O -J -L -H "Content-Type: application/json" -d @all.json 'https://start.microprofile.io/api/1.0.0/project'
+$ curl -O -J -L -H "Content-Type: application/json" -d @all.json 'https://start.microprofile.io/api/1/project'
 
 curl: Saved to filename 'myapp.zip'
 ```
@@ -150,7 +150,7 @@ curl: Saved to filename 'myapp.zip'
 ## JSON Minimal example
 
 ```
-$ curl -O -J -L -H "Content-Type: application/json" -d '{"supportedServer":"KUMULUZEE"}' 'https://start.microprofile.io/api/1.0.0/project'
+$ curl -O -J -L -H "Content-Type: application/json" -d '{"supportedServer":"KUMULUZEE"}' 'https://start.microprofile.io/api/1/project'
 
 curl: Saved to filename 'demo.zip'
 ```
@@ -160,7 +160,7 @@ curl: Saved to filename 'demo.zip'
 Note that if you select an invalid combination of selectedSpecs and supportedServer and mpVersion you get an error, e.g.:
 
 ```
-$ curl -v -O -J -L 'https://start.microprofile.io/api/1.0.0/project?supportedServer=HELIDON&selectedSpecs=REST_CLIENT'
+$ curl -v -O -J -L 'https://start.microprofile.io/api/1/project?supportedServer=HELIDON&selectedSpecs=REST_CLIENT'
 
 curl: Saved to filename 'error.json'
 
@@ -171,7 +171,7 @@ $ cat error.json
 What happened: We did not specify mpVersion, so the latest for the given server at the time was selected by default, it means MP12 at the time of writing of this example. MP12 does not offer spec REST_CLIENT as we can see:
 
 ```
-$ curl https://start.microprofile.io/api/1.0.0/mpVersion/MP12
+$ curl https://start.microprofile.io/api/1/mpVersion/MP12
 {
   "supportedServers": [
     "PAYARA_MICRO",
@@ -199,13 +199,13 @@ $ curl https://start.microprofile.io/api/1.0.0/mpVersion/MP12
 Curl is widely available on Windows too, e.g. [https://curl.haxx.se/windows/](https://curl.haxx.se/windows/)
 
 ```
-C:\curl\bin>curl -O -J https://start.microprofile.io/api/1.0.0/project?supportedServer=THORNTAIL_V2
+C:\curl\bin>curl -O -J https://start.microprofile.io/api/1/project?supportedServer=THORNTAIL_V2
 
 curl: Saved to filename 'demo.zip'
 ```
 
 ```
-C:\curl\bin>curl -O -J "https://start.microprofile.io/api/1.0.0/project?supportedServer=TOMEE&selectedSpecs=JWT_AUTH&selectedSpecs=CONFIG"
+C:\curl\bin>curl -O -J "https://start.microprofile.io/api/1/project?supportedServer=TOMEE&selectedSpecs=JWT_AUTH&selectedSpecs=CONFIG"
 
 curl: Saved to filename 'demo.zip'
 ```
@@ -215,7 +215,7 @@ curl: Saved to filename 'demo.zip'
 #### Minimal
 
 ```
-PS C:\> Invoke-WebRequest -OutFile project.zip -Uri https://start.microprofile.io/api/1.0.0/project?supportedServer=LIBERTY
+PS C:\> Invoke-WebRequest -OutFile project.zip -Uri https://start.microprofile.io/api/1/project?supportedServer=LIBERTY
 ```
 
 #### Using JSON
@@ -242,5 +242,5 @@ PS C:\> type .\all.json
 PS C:\> $headers = @{
 >>   "Content-Type" = "application/json"
 >> }
-PS C:\> Invoke-WebRequest -InFile ./all.json -OutFile project.zip -Method Post -Uri "https://start.microprofile.io/api/1.0.0/project" -Headers $headers
+PS C:\> Invoke-WebRequest -InFile ./all.json -OutFile project.zip -Method Post -Uri "https://start.microprofile.io/api/1/project" -Headers $headers
 ```

--- a/src/main/resources/REST-README.md
+++ b/src/main/resources/REST-README.md
@@ -1,0 +1,246 @@
+```
+  __  __ _                _____            __ _ _      
+ |  \/  (_)              |  __ \          / _(_) |     
+ | \  / |_  ___ _ __ ___ | |__) | __ ___ | |_ _| | ___ 
+ | |\/| | |/ __| '__/ _ \|  ___/ '__/ _ \|  _| | |/ _ \
+ | |  | | | (__| | | (_) | |   | | | (_) | | | | |  __/
+ |_|__|_|_|\___|_|  \___/|_|   |_|  \___/|_| |_|_|\___|
+  / ____| |           | |                              
+ | (___ | |_ __ _ _ __| |_ ___ _ __                    
+  \___ \| __/ _` | '__| __/ _ \ '__|                   
+  ____) | || (_| | |  | ||  __/ |                      
+ |_____/ \__\__,_|_|   \__\___|_|                      
+```
+
+# Project generator REST API
+
+This document summarizes examples of MicroProfile Starter web application REST API
+[microprofile/starter/1.0.0](https://app.swaggerhub.com/apis/microprofile/starter/1.0.0)
+
+Each MicroProfile version (mpVersion) offers a suite of specifications (specs) and is implemented
+by a set of application servers (supportedServers).
+
+In order to get a project zip generated one has to select at least the desired server (supportedServer).
+The latest mpVersion with all specs it offers is used by default then.
+
+# Get available MicroProfile versions
+
+```
+$ curl https://start.microprofile.io/api/1.0.0/mpVersion
+
+["MP22","MP21","MP20","MP14","MP13","MP12"]
+```
+
+# Get available supportedServers and specs
+
+Note the order of supportedServers values is pseudorandom each call.
+Note the JSON formatting was altered for this document.
+
+```
+$ curl https://start.microprofile.io/api/1.0.0/mpVersion/MP14
+{
+  "supportedServers": [
+    "PAYARA_MICRO",
+    "LIBERTY",
+    "TOMEE",
+    "KUMULUZEE"
+  ],
+  "specs": [
+    "CONFIG",
+    "FAULT_TOLERANCE",
+    "JWT_AUTH",
+    "HEALTH_METRICS",
+    "HEALTH_CHECKS",
+    "OPEN_API",
+    "OPEN_TRACING",
+    "REST_CLIENT"
+  ]
+}
+```
+
+# Getting project
+
+Curl: ```-O -J``` makes curl to save the zip file in the current directory. ```-L``` makes curl to follow redirects.
+
+## Minimal example
+
+Note that latest available MP version for the supportedServer and All available Specs were selected by default.
+
+```
+$ curl -O -J 'https://start.microprofile.io/api/1.0.0/project?supportedServer=THORNTAIL_V2'
+
+curl: Saved to filename 'demo.zip'
+
+```
+
+## Examples
+
+The only mandatory attribute is ```supportedServer```. One can omit ```-v``` curl flag.
+Note the optional usage of [Etag](https://tools.ietf.org/html/rfc7232#section-2.3) and [If-None-Match](https://tools.ietf.org/html/rfc7232#section-3.2).
+
+```
+$ curl -v -O -J -L 'https://start.microprofile.io/api/1.0.0/project?supportedServer=PAYARA_MICRO&artifactId=XXXXX&mpVersion=MP12&selectedSpecs=FAULT_TOLERANCE&selectedSpecs=JWT_AUTH'
+
+< ETag: "dd085c81"
+
+curl: Saved to filename 'XXXXX.zip'
+```
+
+Note we can use ETag dd085c81 from the previous response:
+
+```
+curl -v -O -J -L -H 'If-None-Match: "dd085c81"' 'https://start.microprofile.io/api/1.0.0/project?supportedServer=PAYARA_MICRO&artifactId=XXXXX&mpVersion=MP12&selectedSpecs=FAULT_TOLERANCE&selectedSpecs=JWT_AUTH'
+
+< HTTP/1.1 304 Not Modified
+```
+
+## Example with all attributes
+
+```
+$ curl -O -J -L 'https://start.microprofile.io/api/1.0.0/project?supportedServer=LIBERTY&groupId=com.example&artifactId=myapp&mpVersion=MP22&javaSEVersion=SE8&selectedSpecs=CONFIG&selectedSpecs=FAULT_TOLERANCE&selectedSpecs=JWT_AUTH&selectedSpecs=HEALTH_METRICS&selectedSpecs=HEALTH_CHECKS&selectedSpecs=OPEN_API&selectedSpecs=OPEN_TRACING&selectedSpecs=REST_CLIENT'
+
+curl: Saved to filename 'myapp.zip'
+```
+
+## Use JSON for get the project
+
+By POSTing a JSON string one can get the same result as with using query parameters above.
+
+```
+$ curl -O -J -L -H "Content-Type: application/json" -d '{"mpVersion":"MP14","supportedServer":"TOMEE","selectedSpecs":["REST_CLIENT","CONFIG"]}' 'https://start.microprofile.io/api/1.0.0/project'
+
+curl: Saved to filename 'demo.zip'
+```
+
+This is how one can have the JSON stored in a file:
+
+```
+$ curl -O -J -L -H "Content-Type: application/json" -d @my.json 'https://start.microprofile.io/api/1.0.0/project'
+
+curl: Saved to filename 'demo.zip'
+```
+
+## JSON All attributes used
+
+```
+$ cat all.json
+{
+  "groupId": "com.example",
+  "artifactId": "myapp",
+  "mpVersion": "MP22",
+  "javaSEVersion": "SE8",
+  "supportedServer": "THORNTAIL_V2",
+  "selectedSpecs": [
+    "CONFIG",
+    "FAULT_TOLERANCE",
+    "JWT_AUTH",
+    "HEALTH_METRICS",
+    "HEALTH_CHECKS",
+    "OPEN_API",
+    "OPEN_TRACING",
+    "REST_CLIENT"
+  ]
+}
+
+$ curl -O -J -L -H "Content-Type: application/json" -d @all.json 'https://start.microprofile.io/api/1.0.0/project'
+
+curl: Saved to filename 'myapp.zip'
+```
+
+## JSON Minimal example
+
+```
+$ curl -O -J -L -H "Content-Type: application/json" -d '{"supportedServer":"KUMULUZEE"}' 'https://start.microprofile.io/api/1.0.0/project'
+
+curl: Saved to filename 'demo.zip'
+```
+
+# Errors
+
+Note that if you select an invalid combination of selectedSpecs and supportedServer and mpVersion you get an error, e.g.:
+
+```
+$ curl -v -O -J -L 'https://start.microprofile.io/api/1.0.0/project?supportedServer=HELIDON&selectedSpecs=REST_CLIENT'
+
+curl: Saved to filename 'error.json'
+
+$ cat error.json 
+{"error":"One or more selectedSpecs is not available for given mpVersion","code":"ERROR003"}
+```
+
+What happened: We did not specify mpVersion, so the latest for the given server at the time was selected by default, it means MP12 at the time of writing of this example. MP12 does not offer spec REST_CLIENT as we can see:
+
+```
+$ curl https://start.microprofile.io/api/1.0.0/mpVersion/MP12
+{
+  "supportedServers": [
+    "PAYARA_MICRO",
+    "THORNTAIL_V2",
+    "KUMULUZEE",
+    "TOMEE",
+    "HELIDON",
+    "WILDFLY_SWARM",
+    "LIBERTY"
+  ],
+  "specs": [
+    "CONFIG",
+    "FAULT_TOLERANCE",
+    "JWT_AUTH",
+    "HEALTH_METRICS",
+    "HEALTH_CHECKS"
+  ]
+}
+```
+
+## Windows users
+
+### curl.exe examples
+
+Curl is widely available on Windows too, e.g. [https://curl.haxx.se/windows/](https://curl.haxx.se/windows/)
+
+```
+C:\curl\bin>curl -O -J https://start.microprofile.io/api/1.0.0/project?supportedServer=THORNTAIL_V2
+
+curl: Saved to filename 'demo.zip'
+```
+
+```
+C:\curl\bin>curl -O -J "https://start.microprofile.io/api/1.0.0/project?supportedServer=TOMEE&selectedSpecs=JWT_AUTH&selectedSpecs=CONFIG"
+
+curl: Saved to filename 'demo.zip'
+```
+
+### Powershell examples
+
+#### Minimal
+
+```
+PS C:\> Invoke-WebRequest -OutFile project.zip -Uri https://start.microprofile.io/api/1.0.0/project?supportedServer=LIBERTY
+```
+
+#### Using JSON
+
+```
+PS C:\> type .\all.json
+{
+  "groupId": "com.example",
+  "artifactId": "myapp",
+  "mpVersion": "MP22",
+  "javaSEVersion": "SE8",
+  "supportedServer": "THORNTAIL_V2",
+  "selectedSpecs": [
+    "CONFIG",
+    "FAULT_TOLERANCE",
+    "JWT_AUTH",
+    "HEALTH_METRICS",
+    "HEALTH_CHECKS",
+    "OPEN_API",
+    "OPEN_TRACING",
+    "REST_CLIENT"
+  ]
+}
+PS C:\> $headers = @{
+>>   "Content-Type" = "application/json"
+>> }
+PS C:\> Invoke-WebRequest -InFile ./all.json -OutFile project.zip -Method Post -Uri "https://start.microprofile.io/api/1.0.0/project" -Headers $headers
+```

--- a/src/main/webapp/index.xhtml
+++ b/src/main/webapp/index.xhtml
@@ -70,13 +70,13 @@
 
                     <p:panelGrid columns="2" columnClasses="ui-grid-col-6, ui-grid-col-6" layout="grid"
                                  styleClass="ui-panelgrid-blank ui-fluid">
-                        <p:inputText id="groupId" value="#{generatorDataBean.engineData.mavenData.groupId}" required="true"
+                        <p:inputText id="groupId" label="groupId" value="#{generatorDataBean.engineData.mavenData.groupId}" required="true"
                                      title="Used as part of the package name so it must comply with the Java rules"
                                      pt:autocomplete="off">
                             <f:validator validatorId="packageNameValidator"/>
                         </p:inputText>
 
-                        <p:inputText id="artifactId" value="#{generatorDataBean.engineData.mavenData.artifactId}" required="true"
+                        <p:inputText id="artifactId" label="artifactId" value="#{generatorDataBean.engineData.mavenData.artifactId}" required="true"
                                      title="Used as part of the package name so it must comply with the Java rules.  Hyphen is converted to . in package name"
                                      pt:autocomplete="off">
                             <f:validator validatorId="packageNameValidator"/>

--- a/src/main/webapp/index.xhtml
+++ b/src/main/webapp/index.xhtml
@@ -184,19 +184,17 @@
                      styleClass="ui-panelgrid-blank ui-fluid">
 
             <h:panelGroup>
-
-                <p>&copy; 2019 Microprofile.
-                    Eclipse MicroProfile is an open source project under the Apache License 2.0. </p>
+                <p>&copy; 2019 Microprofile. Eclipse MicroProfile is an open source project under the Apache License 2.0.</p>
+                <p><h:outputText value="#{generatorDataBean.version.git}"/></p>
             </h:panelGroup>
             <h:panelGroup>
-
                 <ul class="social">
-                    <li><a target="_blank" href="https://twitter.com/microprofileio"><i class="fa fa-twitter"></i>
+                    <li><a target="_blank" href="https://twitter.com/microprofileio"><i class="fa fa-twitter"/>
                     </a></li>
                     <li><a target="_blank" href="https://www.facebook.com/microprofile.io/"><i
-                            class="fa fa-facebook"></i> </a></li>
+                            class="fa fa-facebook"/> </a></li>
                     <li><a target="_blank" href="https://www.linkedin.com/company/microprofileio/"><i
-                            class="fa fa-linkedin"></i> </a></li>
+                            class="fa fa-linkedin"/> </a></li>
                 </ul>
             </h:panelGroup>
         </p:panelGrid>

--- a/src/test/java/org/eclipse/microprofile/starter/DynamoDBLoggerTest.java
+++ b/src/test/java/org/eclipse/microprofile/starter/DynamoDBLoggerTest.java
@@ -19,7 +19,10 @@
  */
 package org.eclipse.microprofile.starter;
 
+import org.eclipse.microprofile.starter.addon.microprofile.servers.model.MicroprofileSpec;
+import org.eclipse.microprofile.starter.addon.microprofile.servers.model.SupportedServer;
 import org.eclipse.microprofile.starter.core.model.JessieMaven;
+import org.eclipse.microprofile.starter.core.model.MicroProfileVersion;
 import org.eclipse.microprofile.starter.log.DynamoDBLogger;
 import org.eclipse.microprofile.starter.view.EngineData;
 import org.junit.Test;
@@ -42,10 +45,10 @@ public class DynamoDBLoggerTest {
         jessieMaven.setGroupId("com.example.hahah");
 
         EngineData engineData = new EngineData();
-        engineData.setMpVersion("2.0");
-        engineData.setSupportedServer("liberty");
-        engineData.setBeansxmlMode("ANNOTATED");
-        engineData.setSelectedSpecs(Stream.of("HEALTH_METRICS", "HEALTH_CHECKS", "REST_CLIENT").collect(Collectors.toList()));
+        engineData.setMpVersion(MicroProfileVersion.MP20.getCode());
+        engineData.setSupportedServer(SupportedServer.LIBERTY.getCode());
+        engineData.setSelectedSpecs(
+                Stream.of(MicroprofileSpec.values()).map(MicroprofileSpec::getCode).collect(Collectors.toList()));
         engineData.setMavenData(jessieMaven);
 
         dynamoDBLogger.log(engineData);

--- a/version.txt.sh
+++ b/version.txt.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+git describe --tags > ./version.txt
+


### PR DESCRIPTION
Hello, the REST API is finished.

For the time being it is available on  https://test-start.microprofile.io/api/1.0.0 but next time something is merged into master, master will overwrite that deployment.

You can play with it locally on localhost:8080/api/1.0.0/ as

Logging into DynamoDB also works:
See:
```
$ aws  --profile cesar --region us-west-1 dynamodb scan --table-name microprofile_test_starter_log  | grep traffic -A2
            "trafficSource": {
                "S": "REST"
            },
--
            "trafficSource": {
                "S": "WEB"
            },

```

# Changes:

    * Updates logging do DynamoDB to log traffic source, WEB or REST
    * Makes JVM shutdown on OOM ExitOnOutOfMemoryError (just as a precaution)
    * REST API Examples: see [REST-README.md](https://github.com/Karm/microprofile-starter/blob/rest/src/main/resources/REST-README.md)
    * Adds Version string based on git HEAD to both Web UI and REST API
    * README.md file references REST API REST-README.md documentation
    * Thorntail stays at 2.2.1
    * Maven exec plugin uses version.txt.sh to generate version.txt that is then available via Version bean
    * Both REST at /api/1.0.0 and Web UI display the version number (either a tag or tag+commits and hash)
    * API Application and Endpoint separated into 2 classes
    * Error json messages contain error code
    * ETag generation takes Version into account
    * REST-README.md adds links to ETag spec
    * REST-README.md adds examples for Windows users

# REST API Examples:

  see  see [REST-README.md](https://github.com/Karm/microprofile-starter/blob/rest/src/main/resources/REST-README.md)

# UI change: Version number
![vesion-MicroProfile](https://user-images.githubusercontent.com/691097/58874522-5a1e6280-86c9-11e9-9318-49ac9083bef6.png)

Signed-off-by: Michal Karm Babacek <karm@fedoraproject.org>
