### PR TITLE
Changes REST, spec descriptions for /supportMatrix and /supportMatrix/servers

### DIFF
--- a/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/model/MicroprofileSpec.java
+++ b/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/model/MicroprofileSpec.java
@@ -30,27 +30,35 @@ import java.util.List;
 public enum MicroprofileSpec {
     // @formatter:off
     CONFIG("config", "Config",
+            "Configuration - externalize and manage your configuration parameters outside your microservices",
             Arrays.asList(MicroProfileVersion.MP12, MicroProfileVersion.MP13, MicroProfileVersion.MP14,
                     MicroProfileVersion.MP20, MicroProfileVersion.MP21, MicroProfileVersion.MP22))
     , FAULT_TOLERANCE("fault_tolerance", "Fault Tolerance",
+            "Fault Tolerance - all about bulkheads, timeouts, circuit breakers, retries, etc. for your microservices",
             Arrays.asList(MicroProfileVersion.MP12, MicroProfileVersion.MP13, MicroProfileVersion.MP14,
                     MicroProfileVersion.MP20, MicroProfileVersion.MP21, MicroProfileVersion.MP22))
     , JWT_AUTH("JWT_auth", "JWT Auth",
+            "JWT Propagation - propagate security across your microservices",
             Arrays.asList(MicroProfileVersion.MP12, MicroProfileVersion.MP13, MicroProfileVersion.MP14,
                     MicroProfileVersion.MP20, MicroProfileVersion.MP21, MicroProfileVersion.MP22))
     , METRICS("metrics", "Metrics",
+            "Metrics - Gather and create operational and business measurements for your microservices",
             Arrays.asList(MicroProfileVersion.MP12, MicroProfileVersion.MP13, MicroProfileVersion.MP14,
                     MicroProfileVersion.MP20, MicroProfileVersion.MP21, MicroProfileVersion.MP22))
     , HEALTH_CHECKS("health_checks", "Health Checks",
+            "Health Checks - Verify the health of your microservices with custom verifications",
             Arrays.asList(MicroProfileVersion.MP12, MicroProfileVersion.MP13, MicroProfileVersion.MP14,
                     MicroProfileVersion.MP20, MicroProfileVersion.MP21, MicroProfileVersion.MP22))
     , OPEN_API("open_API", "OpenAPI",
+            "Open API - Generate OpenAPI-compliant API documentation for your microservices",
             Arrays.asList(MicroProfileVersion.MP13, MicroProfileVersion.MP14, MicroProfileVersion.MP20,
                     MicroProfileVersion.MP21, MicroProfileVersion.MP22))
     , OPEN_TRACING("open_tracing", "OpenTracing",
+            "Open Tracing - trace the flow of requests as they traverse your microservices",
             Arrays.asList(MicroProfileVersion.MP13, MicroProfileVersion.MP14, MicroProfileVersion.MP20,
                     MicroProfileVersion.MP21, MicroProfileVersion.MP22))
     , REST_CLIENT("rest_client", "TypeSafe Rest Client",
+            "Rest Client - Invoke RESTful services in a type-safe manner",
             Arrays.asList(MicroProfileVersion.MP13, MicroProfileVersion.MP14, MicroProfileVersion.MP20,
                     MicroProfileVersion.MP21, MicroProfileVersion.MP22))
     ;
@@ -58,17 +66,23 @@ public enum MicroprofileSpec {
 
     private String code;
     private String label;
+    private String description;
     private List<MicroProfileVersion> mpVersions;
 
-    MicroprofileSpec(String code, String label, List<MicroProfileVersion> mpVersions) {
+    MicroprofileSpec(String code, String label, String description, List<MicroProfileVersion> mpVersions) {
         this.code = code;
         this.label = label;
+        this.description = description;
 
         this.mpVersions = mpVersions;
     }
 
     public String getCode() {
         return code;
+    }
+
+    public String getDescription() {
+        return description;
     }
 
     public List<MicroProfileVersion> getMpVersions() {

--- a/src/main/java/org/eclipse/microprofile/starter/rest/APIEndpointV2.java
+++ b/src/main/java/org/eclipse/microprofile/starter/rest/APIEndpointV2.java
@@ -19,36 +19,12 @@
  */
 package org.eclipse.microprofile.starter.rest;
 
-import javax.inject.Inject;
-import javax.ws.rs.GET;
-import javax.ws.rs.HeaderParam;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.Response;
 
 /**
  * @author Michal Karm Babacek <karm@redhat.com>
  */
-@Path("/1")
-public class APIEndpointV1 extends APIEndpointLatest {
+@Path("/2")
+public class APIEndpointV2 extends APIEndpointLatest {
 
-    @Inject
-    private APIService api;
-
-    @Path("/supportMatrix")
-    @GET
-    @Produces({"application/json"})
-    @Override
-    public Response supportMatrix(@HeaderParam(HttpHeaders.IF_NONE_MATCH) String ifNoneMatch) {
-        return api.supportMatrixV1(ifNoneMatch);
-    }
-
-    @Path("/supportMatrix/servers")
-    @GET
-    @Produces({"application/json"})
-    @Override
-    public Response supportMatrixServers(@HeaderParam(HttpHeaders.IF_NONE_MATCH) String ifNoneMatch) {
-        return api.supportMatrixServersV1(ifNoneMatch);
-    }
 }

--- a/src/main/resources/REST-README.md
+++ b/src/main/resources/REST-README.md
@@ -259,43 +259,55 @@ $ curl -i https://start.microprofile.io/api/1/supportMatrix
 ETag: "44730639"
 ...
 {
-  "MP12": {
-    "supportedServers": [
-      "WILDFLY_SWARM",
-      "PAYARA_MICRO",
-      "THORNTAIL_V2",
-      "TOMEE",
-      "LIBERTY",
-      "KUMULUZEE",
-      "HELIDON"
-    ],
-    "specs": [
-      "CONFIG",
-      "FAULT_TOLERANCE",
-      "JWT_AUTH",
-      "METRICS",
-      "HEALTH_CHECKS"
-    ]
+  "configs": {
+    "MP21": {
+      "supportedServers": [
+        "THORNTAIL_V2",
+        "PAYARA_MICRO",
+        "KUMULUZEE",
+        "LIBERTY"
+      ],
+      "specs": [
+        "CONFIG",
+        "FAULT_TOLERANCE",
+        "JWT_AUTH",
+        "METRICS",
+        "HEALTH_CHECKS",
+        "OPEN_API",
+        "OPEN_TRACING",
+        "REST_CLIENT"
+      ]
+    },
+    "MP22": {
+      "supportedServers": [
+        "PAYARA_MICRO",
+        "LIBERTY",
+        "KUMULUZEE",
+        "THORNTAIL_V2"
+      ],
+      "specs": [
+        "CONFIG",
+        "FAULT_TOLERANCE",
+        "JWT_AUTH",
+        "METRICS",
+        "HEALTH_CHECKS",
+        "OPEN_API",
+        "OPEN_TRACING",
+        "REST_CLIENT"
+      ]
+    },
+  ...more MPxx removed for brevity...
   },
-  "MP21": {
-    "supportedServers": [
-      "KUMULUZEE",
-      "THORNTAIL_V2",
-      "LIBERTY",
-      "PAYARA_MICRO"
-    ],
-    "specs": [
-      "CONFIG",
-      "FAULT_TOLERANCE",
-      "JWT_AUTH",
-      "METRICS",
-      "HEALTH_CHECKS",
-      "OPEN_API",
-      "OPEN_TRACING",
-      "REST_CLIENT"
-    ]
-  },
-  ...removed for brevity...
+  "descriptions": {
+    "CONFIG": "Configuration - externalize and manage your configuration parameters outside your microservices",
+    "OPEN_API": "Open API - Generate OpenAPI-compliant API documentation for your microservices",
+    "HEALTH_CHECKS": "Health Checks - Verify the health of your microservices with custom verifications",
+    "REST_CLIENT": "Rest Client - Invoke RESTful services in a type-safe manner",
+    "FAULT_TOLERANCE": "Fault Tolerance - all about bulkheads, timeouts, circuit breakers, retries, etc. for your microservices",
+    "JWT_AUTH": "JWT Propagation - propagate security across your microservices",
+    "OPEN_TRACING": "Open Tracing - trace the flow of requests as they traverse your microservices",
+    "METRICS": "Metrics - Gather and create operational and business measurements for your microservices"
+  }
 }
 ```
 
@@ -315,75 +327,117 @@ $ curl -i https://start.microprofile.io/api/1/supportMatrix/servers
 ETag: "7b99230f"
 ...
 {
-  "HELIDON": {
-    "MP12": [
-      "CONFIG",
-      "FAULT_TOLERANCE",
-      "JWT_AUTH",
-      "METRICS",
-      "HEALTH_CHECKS"
-    ]
+  "configs": {
+    "PAYARA_MICRO": {
+      "MP21": [
+        "CONFIG",
+        "FAULT_TOLERANCE",
+        "JWT_AUTH",
+        "METRICS",
+        "HEALTH_CHECKS",
+        "OPEN_API",
+        "OPEN_TRACING",
+        "REST_CLIENT"
+      ],
+      "MP22": [
+        "CONFIG",
+        "FAULT_TOLERANCE",
+        "JWT_AUTH",
+        "METRICS",
+        "HEALTH_CHECKS",
+        "OPEN_API",
+        "OPEN_TRACING",
+        "REST_CLIENT"
+      ],
+      "MP12": [
+        "CONFIG",
+        "FAULT_TOLERANCE",
+        "JWT_AUTH",
+        "METRICS",
+        "HEALTH_CHECKS"
+      ],
+      "MP13": [
+        "CONFIG",
+        "FAULT_TOLERANCE",
+        "JWT_AUTH",
+        "METRICS",
+        "HEALTH_CHECKS",
+        "OPEN_API",
+        "OPEN_TRACING",
+        "REST_CLIENT"
+      ],
+      "MP14": [
+        "CONFIG",
+        "FAULT_TOLERANCE",
+        "JWT_AUTH",
+        "METRICS",
+        "HEALTH_CHECKS",
+        "OPEN_API",
+        "OPEN_TRACING",
+        "REST_CLIENT"
+      ],
+      "MP20": [
+        "CONFIG",
+        "FAULT_TOLERANCE",
+        "JWT_AUTH",
+        "METRICS",
+        "HEALTH_CHECKS",
+        "OPEN_API",
+        "OPEN_TRACING",
+        "REST_CLIENT"
+      ]
+    },
+    "THORNTAIL_V2": {
+      "MP21": [
+        "CONFIG",
+        "FAULT_TOLERANCE",
+        "JWT_AUTH",
+        "METRICS",
+        "HEALTH_CHECKS",
+        "OPEN_API",
+        "OPEN_TRACING",
+        "REST_CLIENT"
+      ],
+      "MP22": [
+        "CONFIG",
+        "FAULT_TOLERANCE",
+        "JWT_AUTH",
+        "METRICS",
+        "HEALTH_CHECKS",
+        "OPEN_API",
+        "OPEN_TRACING",
+        "REST_CLIENT"
+      ],
+      "MP12": [
+        "CONFIG",
+        "FAULT_TOLERANCE",
+        "JWT_AUTH",
+        "METRICS",
+        "HEALTH_CHECKS"
+      ],
+      "MP13": [
+        "CONFIG",
+        "FAULT_TOLERANCE",
+        "JWT_AUTH",
+        "METRICS",
+        "HEALTH_CHECKS",
+        "OPEN_API",
+        "OPEN_TRACING",
+        "REST_CLIENT"
+      ]
+    },
+...more servers removed for brevity...
   },
-  "PAYARA_MICRO": {
-    "MP20": [
-      "CONFIG",
-      "FAULT_TOLERANCE",
-      "JWT_AUTH",
-      "METRICS",
-      "HEALTH_CHECKS",
-      "OPEN_API",
-      "OPEN_TRACING",
-      "REST_CLIENT"
-    ],
-    "MP13": [
-      "CONFIG",
-      "FAULT_TOLERANCE",
-      "JWT_AUTH",
-      "METRICS",
-      "HEALTH_CHECKS",
-      "OPEN_API",
-      "OPEN_TRACING",
-      "REST_CLIENT"
-    ],
-    "MP22": [
-      "CONFIG",
-      "FAULT_TOLERANCE",
-      "JWT_AUTH",
-      "METRICS",
-      "HEALTH_CHECKS",
-      "OPEN_API",
-      "OPEN_TRACING",
-      "REST_CLIENT"
-    ],
-    "MP12": [
-      "CONFIG",
-      "FAULT_TOLERANCE",
-      "JWT_AUTH",
-      "METRICS",
-      "HEALTH_CHECKS"
-    ],
-    "MP14": [
-      "CONFIG",
-      "FAULT_TOLERANCE",
-      "JWT_AUTH",
-      "METRICS",
-      "HEALTH_CHECKS",
-      "OPEN_API",
-      "OPEN_TRACING",
-      "REST_CLIENT"
-    ],
-    "MP21": [
-      "CONFIG",
-      "FAULT_TOLERANCE",
-      "JWT_AUTH",
-      "METRICS",
-      "HEALTH_CHECKS",
-      "OPEN_API",
-      "OPEN_TRACING",
-      "REST_CLIENT"
-    ]
+  "descriptions": {
+    "CONFIG": "Configuration - externalize and manage your configuration parameters outside your microservices",
+    "OPEN_API": "Open API - Generate OpenAPI-compliant API documentation for your microservices",
+    "HEALTH_CHECKS": "Health Checks - ensure your microservices is up and running by enabling health checks",
+    "REST_CLIENT": "Rest Client - Invoke RESTful services in a type-safe manner",
+    "FAULT_TOLERANCE": "Fault Tolerance - all about bulkheads, timeouts, circuit breakers, retries, etc. for your microservices",
+    "JWT_AUTH": "JWT Propagation - manage and propagate security across your microservices",
+    "OPEN_TRACING": "Open Tracing - trace the flow of requests as they traverse your microservices",
+    "METRICS": "Metrics - Gather and create operational and business measurements for your microservices"
   }
-  ...removed for brevity...
 }
 ```
 


### PR DESCRIPTION
Fixes #183 

New top level attributes are added, "configs" and "descriptions".
"configs" contain what /supportMatrix/servers and /supportMatrix used to contain.
"descriptions" displays mapping between spec names and their legend.

Note that it changes already released API v1. I think it is kinda O.K. in our case as these specific resources are intended for [VSCode Extension](https://github.com/microprofile-starter-extensions/vscode-microprofile). If you don't like it, I will refactor it to API v2.

Note the MP specs are not sorted in this PR. Sorting PR is #186 

[See full examples on how it looks like now.](https://gist.github.com/Karm/e34fa6676b8bff43f70e3e9fa053cf16)

[REST-README.md](https://github.com/Karm/microprofile-starter/blob/issue-183/src/main/resources/REST-README.md#microprofile-versions-as-keys) was also updated.

