### PR TITLE
Changed to use Thorntail 2.5.0.Final. Fixes #196

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <inceptionYear>2017</inceptionYear>
 
     <properties>
-        <version.thorntail>2.2.1.Final</version.thorntail>
+        <version.thorntail>2.5.0.Final</version.thorntail>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.exec.plugin.version>1.6.0</maven.exec.plugin.version>


### PR DESCRIPTION
This allows project to be built with Maven 3.6.0 and above

Signed-off-by: David Salter <wedevelopinjava@gmail.com>