### PR TITLE
Fixes issue 204, adds link to REST API to the footer of the web page

### DIFF
--- a/src/main/webapp/index.xhtml
+++ b/src/main/webapp/index.xhtml
@@ -185,6 +185,8 @@
 
             <h:panelGroup>
                 <p>&copy; 2019 Microprofile. Eclipse MicroProfile is an open source project under the Apache License 2.0.</p>
+                <p id="REST"></p>
+                <script src="resources/script/getHost.js"></script>
                 <p><h:outputText value="#{generatorDataBean.version.git}"/></p>
             </h:panelGroup>
             <h:panelGroup>

--- a/src/main/webapp/resources/script/getHost.js
+++ b/src/main/webapp/resources/script/getHost.js
@@ -1,1 +1,1 @@
-document.getElementById("REST").innerHTML = "REST API: $ curl  '"+window.location.protocol+"//"+window.location.host+"/api'";
+document.getElementById("REST").innerHTML = "Command line: curl '"+window.location.protocol+"//"+window.location.host+"/api'";

--- a/src/main/webapp/resources/script/getHost.js
+++ b/src/main/webapp/resources/script/getHost.js
@@ -1,0 +1,1 @@
+document.getElementById("REST").innerHTML = "REST API: $ curl  '"+window.location.protocol+"//"+window.location.host+"/api'";


### PR DESCRIPTION
# Link to REST API

It occurs to me that visitors might want to know there is a REST API available. This PR includes a small JavaScript that stitches together the current URL to the API and displays it convenient as curl command, ready to be copy-pasted.   Is it O.K. @rstjames ?   
![Screenshot_2019-08-28 Starter MicroProfile](https://user-images.githubusercontent.com/691097/63852353-5df41500-c998-11e9-9d48-117421283553.png)

You can see it live on my dev instance: https://starter2.karms.biz/ 

