### PR TITLE
Changes API to generate no examples when no specs are selected, fixes issue 237

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ log.txt
 .classpath
 .settings/
 .vscode
+download.sh
+.checkstyle

--- a/src/main/java/org/eclipse/microprofile/starter/rest/APIEndpointLatest.java
+++ b/src/main/java/org/eclipse/microprofile/starter/rest/APIEndpointLatest.java
@@ -92,8 +92,9 @@ public class APIEndpointLatest {
                                @QueryParam("artifactId") String artifactId,
                                @QueryParam("mpVersion") MicroProfileVersion mpVersion,
                                @QueryParam("javaSEVersion") JavaSEVersion javaSEVersion,
-                               @QueryParam("selectedSpecs") List<MicroprofileSpec> selectedSpecs) {
-        return api.getProject(ifNoneMatch, supportedServer, groupId, artifactId, mpVersion, javaSEVersion, selectedSpecs);
+                               @QueryParam("selectedSpecs") List<MicroprofileSpec> selectedSpecs,
+                               @QueryParam("selectAllSpecs") boolean selectAllSpecs) {
+        return api.getProject(ifNoneMatch, supportedServer, groupId, artifactId, mpVersion, javaSEVersion, selectedSpecs, selectAllSpecs);
     }
 
     @Path("/project")

--- a/src/main/java/org/eclipse/microprofile/starter/rest/APIEndpointV1.java
+++ b/src/main/java/org/eclipse/microprofile/starter/rest/APIEndpointV1.java
@@ -19,15 +19,29 @@
  */
 package org.eclipse.microprofile.starter.rest;
 
+import org.eclipse.microprofile.starter.addon.microprofile.servers.model.MicroprofileSpec;
+import org.eclipse.microprofile.starter.addon.microprofile.servers.model.SupportedServer;
+import org.eclipse.microprofile.starter.core.model.JavaSEVersion;
+import org.eclipse.microprofile.starter.core.model.MicroProfileVersion;
+import org.eclipse.microprofile.starter.rest.model.Project;
+
 import javax.inject.Inject;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
+import java.util.List;
 
 /**
+ * Overwrites methods that are changed in subsequent APIs
+ * to retain former behaviour.
+ *
  * @author Michal Karm Babacek <karm@redhat.com>
  */
 @Path("/1")
@@ -50,5 +64,27 @@ public class APIEndpointV1 extends APIEndpointLatest {
     @Override
     public Response supportMatrixServers(@HeaderParam(HttpHeaders.IF_NONE_MATCH) String ifNoneMatch) {
         return api.supportMatrixServersV1(ifNoneMatch);
+    }
+
+    @Path("/project")
+    @GET
+    @Produces({"application/zip", "application/json"})
+    public Response getProject(@HeaderParam(HttpHeaders.IF_NONE_MATCH) String ifNoneMatch,
+                               @QueryParam("supportedServer") SupportedServer supportedServer,
+                               @QueryParam("groupId") String groupId,
+                               @QueryParam("artifactId") String artifactId,
+                               @QueryParam("mpVersion") MicroProfileVersion mpVersion,
+                               @QueryParam("javaSEVersion") JavaSEVersion javaSEVersion,
+                               @QueryParam("selectedSpecs") List<MicroprofileSpec> selectedSpecs) {
+        return api.getProjectV1(ifNoneMatch, supportedServer, groupId, artifactId, mpVersion, javaSEVersion, selectedSpecs);
+    }
+
+    @Path("/project")
+    @POST
+    @Consumes({"application/json"})
+    @Produces({"application/zip", "application/json"})
+    @Override
+    public Response projectPost(@HeaderParam(HttpHeaders.IF_NONE_MATCH) String ifNoneMatch, @NotNull Project body) {
+        return api.getProjectV1(ifNoneMatch, body);
     }
 }

--- a/src/main/java/org/eclipse/microprofile/starter/rest/APIEndpointV2.java
+++ b/src/main/java/org/eclipse/microprofile/starter/rest/APIEndpointV2.java
@@ -19,12 +19,57 @@
  */
 package org.eclipse.microprofile.starter.rest;
 
+import org.eclipse.microprofile.starter.addon.microprofile.servers.model.MicroprofileSpec;
+import org.eclipse.microprofile.starter.addon.microprofile.servers.model.SupportedServer;
+import org.eclipse.microprofile.starter.core.model.JavaSEVersion;
+import org.eclipse.microprofile.starter.core.model.MicroProfileVersion;
+import org.eclipse.microprofile.starter.rest.model.Project;
+
+import javax.inject.Inject;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+import java.util.List;
 
 /**
+ * Overwrites methods that are changed in next version,
+ * e.g. if getProject behaviour was changed in next version,
+ * this retains the former behaviour (which is the same as in V1 in getProject's case).
+ *
  * @author Michal Karm Babacek <karm@redhat.com>
  */
 @Path("/2")
 public class APIEndpointV2 extends APIEndpointLatest {
 
+    @Inject
+    private APIService api;
+
+    @Path("/project")
+    @GET
+    @Produces({"application/zip", "application/json"})
+    public Response getProject(@HeaderParam(HttpHeaders.IF_NONE_MATCH) String ifNoneMatch,
+                               @QueryParam("supportedServer") SupportedServer supportedServer,
+                               @QueryParam("groupId") String groupId,
+                               @QueryParam("artifactId") String artifactId,
+                               @QueryParam("mpVersion") MicroProfileVersion mpVersion,
+                               @QueryParam("javaSEVersion") JavaSEVersion javaSEVersion,
+                               @QueryParam("selectedSpecs") List<MicroprofileSpec> selectedSpecs) {
+        return api.getProjectV1(ifNoneMatch, supportedServer, groupId, artifactId, mpVersion, javaSEVersion, selectedSpecs);
+    }
+
+    @Path("/project")
+    @POST
+    @Consumes({"application/json"})
+    @Produces({"application/zip", "application/json"})
+    @Override
+    public Response projectPost(@HeaderParam(HttpHeaders.IF_NONE_MATCH) String ifNoneMatch, @NotNull Project body) {
+        return api.getProjectV1(ifNoneMatch, body);
+    }
 }

--- a/src/main/java/org/eclipse/microprofile/starter/rest/APIEndpointV3.java
+++ b/src/main/java/org/eclipse/microprofile/starter/rest/APIEndpointV3.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.eclipse.microprofile.starter.rest;
+
+import javax.ws.rs.Path;
+
+/**
+ * @author Michal Karm Babacek <karm@redhat.com>
+ */
+@Path("/3")
+public class APIEndpointV3 extends APIEndpointLatest {
+
+    // Does not differ from latest in anything.
+
+}

--- a/src/main/java/org/eclipse/microprofile/starter/rest/model/Project.java
+++ b/src/main/java/org/eclipse/microprofile/starter/rest/model/Project.java
@@ -27,7 +27,9 @@ import org.eclipse.microprofile.starter.core.model.MicroProfileVersion;
 import java.util.List;
 import java.util.Objects;
 
-
+/**
+ * @author Michal Karm Babacek <karm@redhat.com>
+ */
 public class Project {
     private String groupId = null;
     private String artifactId = null;
@@ -35,6 +37,7 @@ public class Project {
     private JavaSEVersion javaSEVersion = null;
     private SupportedServer supportedServer = null;
     private List<MicroprofileSpec> selectedSpecs = null;
+    private boolean selectAllSpecs = false;
 
     public String getGroupId() {
         return groupId;
@@ -84,6 +87,14 @@ public class Project {
         this.selectedSpecs = selectedSpecs;
     }
 
+    public boolean isSelectAllSpecs() {
+        return selectAllSpecs;
+    }
+
+    public void setSelectAllSpecs(boolean selectAllSpecs) {
+        this.selectAllSpecs = selectAllSpecs;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -98,11 +109,12 @@ public class Project {
                 mpVersion == project.mpVersion &&
                 javaSEVersion == project.javaSEVersion &&
                 supportedServer == project.supportedServer &&
+                selectAllSpecs == project.selectAllSpecs &&
                 Objects.equals(selectedSpecs, project.selectedSpecs);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(groupId, artifactId, mpVersion, javaSEVersion, supportedServer, selectedSpecs);
+        return Objects.hash(groupId, artifactId, mpVersion, javaSEVersion, supportedServer, selectedSpecs, selectAllSpecs);
     }
 }

--- a/src/main/resources/REST-README.md
+++ b/src/main/resources/REST-README.md
@@ -21,12 +21,17 @@ Each MicroProfile version (mpVersion) offers a suite of specifications (specs) a
 by a set of application servers (supportedServers).
 
 In order to get a project zip generated one has to select at least the desired server (supportedServer).
-The latest mpVersion with all specs it offers is used by default then.
+The latest mpVersion with no specs but the basic hello world JAX-RS endpoint is used by default then.
+
+# Versions
+
+There are currently 3 versions of the API to retain backward compatibility. ```/api/``` is the latest;
+use e.g. ```/api/1/``` to get the legacy behaviour.
 
 # Get available MicroProfile versions
 
 ```
-$ curl https://start.microprofile.io/api/1/mpVersion
+$ curl https://start.microprofile.io/api/mpVersion
 
 ["MP22","MP21","MP20","MP14","MP13","MP12"]
 ```
@@ -37,24 +42,25 @@ Note the order of supportedServers values is pseudorandom each call.
 Note the JSON formatting was altered for this document.
 
 ```
-$ curl https://start.microprofile.io/api/1/mpVersion/MP14
+$ curl https://start.microprofile.io/api/mpVersion/MP22
 {
-  "supportedServers": [
-    "PAYARA_MICRO",
-    "LIBERTY",
-    "TOMEE",
-    "KUMULUZEE"
-  ],
-  "specs": [
-    "CONFIG",
-    "FAULT_TOLERANCE",
-    "JWT_AUTH",
-    "METRICS",
-    "HEALTH_CHECKS",
-    "OPEN_API",
-    "OPEN_TRACING",
-    "REST_CLIENT"
-  ]
+    "supportedServers": [
+        "PAYARA_MICRO",
+        "LIBERTY",
+        "KUMULUZEE",
+        "THORNTAIL_V2",
+        "HELIDON"
+    ],
+    "specs": [
+        "CONFIG",
+        "FAULT_TOLERANCE",
+        "JWT_AUTH",
+        "METRICS",
+        "HEALTH_CHECKS",
+        "OPEN_API",
+        "OPEN_TRACING",
+        "REST_CLIENT"
+    ]
 }
 ```
 
@@ -64,10 +70,28 @@ Curl: ```-O -J``` makes curl to save the zip file in the current directory. ```-
 
 ## Minimal example
 
-Note that latest available MP version for the supportedServer and All available Specs were selected by default.
+Note that latest available MP version for the supportedServer and **No** available Specs were selected by default.
 
 ```
-$ curl -O -J 'https://start.microprofile.io/api/1/project?supportedServer=THORNTAIL_V2'
+$ curl -O -J 'https://start.microprofile.io/api/project?supportedServer=THORNTAIL_V2'
+
+curl: Saved to filename 'demo.zip'
+
+```
+
+On the contrary, when API version 1 or 2 is used, **All** available Specs are selected by default.
+
+```
+$ curl -O -J 'https://start.microprofile.io/api/2/project?supportedServer=THORNTAIL_V2'
+
+curl: Saved to filename 'demo.zip'
+
+```
+
+To get **All** available specs with the current latest API, use ```selectAllSpecs=true``` query param in the URL, e.g.:
+
+```
+$ curl -O -J 'https://start.microprofile.io/api/project?supportedServer=THORNTAIL_V2&selectAllSpecs=true'
 
 curl: Saved to filename 'demo.zip'
 
@@ -79,7 +103,7 @@ The only mandatory attribute is ```supportedServer```. One can omit ```-v``` cur
 Note the optional usage of [Etag](https://tools.ietf.org/html/rfc7232#section-2.3) and [If-None-Match](https://tools.ietf.org/html/rfc7232#section-3.2).
 
 ```
-$ curl -v -O -J -L 'https://start.microprofile.io/api/1/project?supportedServer=PAYARA_MICRO&artifactId=XXXXX&mpVersion=MP12&selectedSpecs=FAULT_TOLERANCE&selectedSpecs=JWT_AUTH'
+$ curl -v -O -J -L 'https://start.microprofile.io/api/project?supportedServer=PAYARA_MICRO&artifactId=XXXXX&mpVersion=MP12&selectedSpecs=FAULT_TOLERANCE&selectedSpecs=JWT_AUTH'
 
 < ETag: "dd085c81"
 
@@ -89,7 +113,7 @@ curl: Saved to filename 'XXXXX.zip'
 Note we can use ETag dd085c81 from the previous response:
 
 ```
-curl -v -O -J -L -H 'If-None-Match: "dd085c81"' 'https://start.microprofile.io/api/1/project?supportedServer=PAYARA_MICRO&artifactId=XXXXX&mpVersion=MP12&selectedSpecs=FAULT_TOLERANCE&selectedSpecs=JWT_AUTH'
+curl -v -O -J -L -H 'If-None-Match: "dd085c81"' 'https://start.microprofile.io/api/project?supportedServer=PAYARA_MICRO&artifactId=XXXXX&mpVersion=MP12&selectedSpecs=FAULT_TOLERANCE&selectedSpecs=JWT_AUTH'
 
 < HTTP/1.1 304 Not Modified
 ```
@@ -97,7 +121,7 @@ curl -v -O -J -L -H 'If-None-Match: "dd085c81"' 'https://start.microprofile.io/a
 ## Example with all attributes
 
 ```
-$ curl -O -J -L 'https://start.microprofile.io/api/1/project?supportedServer=LIBERTY&groupId=com.example&artifactId=myapp&mpVersion=MP22&javaSEVersion=SE8&selectedSpecs=CONFIG&selectedSpecs=FAULT_TOLERANCE&selectedSpecs=JWT_AUTH&selectedSpecs=METRICS&selectedSpecs=HEALTH_CHECKS&selectedSpecs=OPEN_API&selectedSpecs=OPEN_TRACING&selectedSpecs=REST_CLIENT'
+$ curl -O -J -L 'https://start.microprofile.io/api/project?supportedServer=LIBERTY&groupId=com.example&artifactId=myapp&mpVersion=MP22&javaSEVersion=SE8&selectedSpecs=CONFIG&selectedSpecs=FAULT_TOLERANCE&selectedSpecs=JWT_AUTH&selectedSpecs=METRICS&selectedSpecs=HEALTH_CHECKS&selectedSpecs=OPEN_API&selectedSpecs=OPEN_TRACING&selectedSpecs=REST_CLIENT'
 
 curl: Saved to filename 'myapp.zip'
 ```
@@ -107,15 +131,19 @@ curl: Saved to filename 'myapp.zip'
 By POSTing a JSON string one can get the same result as with using query parameters above.
 
 ```
-$ curl -O -J -L -H "Content-Type: application/json" -d '{"mpVersion":"MP14","supportedServer":"TOMEE","selectedSpecs":["REST_CLIENT","CONFIG"]}' 'https://start.microprofile.io/api/1/project'
+$ curl -O -J -L -H "Content-Type: application/json" -d '{"mpVersion":"MP14","supportedServer":"TOMEE","selectedSpecs":["REST_CLIENT","CONFIG"]}' 'https://start.microprofile.io/api/project'
 
 curl: Saved to filename 'demo.zip'
 ```
 
+Note that if you omit ```"selectedSpecs":["REST_CLIENT","CONFIG"]```, nothing but a single Hello World JAX-RS resource is generated.
+On the other hand, if you add ```"selectAllSpecs":"true"```, all available specs within given ```mpVersion``` are generated. The legacy ```/api/2/``` and prior
+behaviour was to give you all available specs when none was selected.
+
 This is how one can have the JSON stored in a file:
 
 ```
-$ curl -O -J -L -H "Content-Type: application/json" -d @my.json 'https://start.microprofile.io/api/1/project'
+$ curl -O -J -L -H "Content-Type: application/json" -d @my.json 'https://start.microprofile.io/api/project'
 
 curl: Saved to filename 'demo.zip'
 ```
@@ -142,15 +170,17 @@ $ cat all.json
   ]
 }
 
-$ curl -O -J -L -H "Content-Type: application/json" -d @all.json 'https://start.microprofile.io/api/1/project'
+$ curl -O -J -L -H "Content-Type: application/json" -d @all.json 'https://start.microprofile.io/api/project'
 
 curl: Saved to filename 'myapp.zip'
 ```
 
 ## JSON Minimal example
 
+Add ```"selectAllSpecs":"true"``` to get all specs examples.
+
 ```
-$ curl -O -J -L -H "Content-Type: application/json" -d '{"supportedServer":"KUMULUZEE"}' 'https://start.microprofile.io/api/1/project'
+$ curl -O -J -L -H "Content-Type: application/json" -d '{"supportedServer":"KUMULUZEE"}' 'https://start.microprofile.io/api/project'
 
 curl: Saved to filename 'demo.zip'
 ```
@@ -160,7 +190,7 @@ curl: Saved to filename 'demo.zip'
 Note that if you select an invalid combination of selectedSpecs and supportedServer and mpVersion you get an error, e.g.:
 
 ```
-$ curl -v -O -J -L 'https://start.microprofile.io/api/1/project?supportedServer=HELIDON&selectedSpecs=REST_CLIENT'
+$ curl -v -O -J -L 'https://start.microprofile.io/api/project?supportedServer=HELIDON&selectedSpecs=REST_CLIENT'
 
 curl: Saved to filename 'error.json'
 
@@ -171,7 +201,7 @@ $ cat error.json
 What happened: We did not specify mpVersion, so the latest for the given server at the time was selected by default, it means MP12 at the time of writing of this example. MP12 does not offer spec REST_CLIENT as we can see:
 
 ```
-$ curl https://start.microprofile.io/api/1/mpVersion/MP12
+$ curl https://start.microprofile.io/api/mpVersion/MP12
 {
   "supportedServers": [
     "PAYARA_MICRO",
@@ -199,13 +229,13 @@ $ curl https://start.microprofile.io/api/1/mpVersion/MP12
 Curl is widely available on Windows too, e.g. [https://curl.haxx.se/windows/](https://curl.haxx.se/windows/)
 
 ```
-C:\curl\bin>curl -O -J https://start.microprofile.io/api/1/project?supportedServer=THORNTAIL_V2
+C:\curl\bin>curl -O -J https://start.microprofile.io/api/project?supportedServer=THORNTAIL_V2&selectAllSpecs=true
 
 curl: Saved to filename 'demo.zip'
 ```
 
 ```
-C:\curl\bin>curl -O -J "https://start.microprofile.io/api/1/project?supportedServer=TOMEE&selectedSpecs=JWT_AUTH&selectedSpecs=CONFIG"
+C:\curl\bin>curl -O -J "https://start.microprofile.io/api/project?supportedServer=TOMEE&selectedSpecs=JWT_AUTH&selectedSpecs=CONFIG"
 
 curl: Saved to filename 'demo.zip'
 ```
@@ -215,7 +245,7 @@ curl: Saved to filename 'demo.zip'
 #### Minimal
 
 ```
-PS C:\> Invoke-WebRequest -OutFile project.zip -Uri https://start.microprofile.io/api/1/project?supportedServer=LIBERTY
+PS C:\> Invoke-WebRequest -OutFile project.zip -Uri https://start.microprofile.io/api/project?supportedServer=LIBERTY
 ```
 
 #### Using JSON
@@ -242,7 +272,7 @@ PS C:\> type .\all.json
 PS C:\> $headers = @{
 >>   "Content-Type" = "application/json"
 >> }
-PS C:\> Invoke-WebRequest -InFile ./all.json -OutFile project.zip -Method Post -Uri "https://start.microprofile.io/api/1/project" -Headers $headers
+PS C:\> Invoke-WebRequest -InFile ./all.json -OutFile project.zip -Method Post -Uri "https://start.microprofile.io/api/project" -Headers $headers
 ```
 
 # Integration with IDEs
@@ -254,67 +284,69 @@ and [If-None-Match](https://tools.ietf.org/html/rfc7232#section-3.2) request hea
 ## MicroProfile versions as keys
 
 ```
-$ curl -i https://start.microprofile.io/api/1/supportMatrix
+$ curl -i https://start.microprofile.io/api/supportMatrix
 ...
 ETag: "44730639"
 ...
 {
-  "configs": {
-    "MP21": {
-      "supportedServers": [
-        "THORNTAIL_V2",
-        "PAYARA_MICRO",
-        "KUMULUZEE",
-        "LIBERTY"
-      ],
-      "specs": [
-        "CONFIG",
-        "FAULT_TOLERANCE",
-        "JWT_AUTH",
-        "METRICS",
-        "HEALTH_CHECKS",
-        "OPEN_API",
-        "OPEN_TRACING",
-        "REST_CLIENT"
-      ]
+    "configs": {
+        "MP30": {
+            "supportedServers": [
+                "LIBERTY",
+                "THORNTAIL_V2",
+                "HELIDON"
+            ],
+            "specs": [
+                "CONFIG",
+                "FAULT_TOLERANCE",
+                "JWT_AUTH",
+                "METRICS",
+                "HEALTH_CHECKS",
+                "OPEN_API",
+                "OPEN_TRACING",
+                "REST_CLIENT"
+            ]
+        },
+        "MP22": {
+            "supportedServers": [
+                "THORNTAIL_V2",
+                "LIBERTY",
+                "KUMULUZEE",
+                "PAYARA_MICRO",
+                "HELIDON"
+            ],
+            "specs": [
+                "CONFIG",
+                "FAULT_TOLERANCE",
+                "JWT_AUTH",
+                "METRICS",
+                "HEALTH_CHECKS",
+                "OPEN_API",
+                "OPEN_TRACING",
+                "REST_CLIENT"
+            ]
+        },
+...
+...other MP versions removed for brevity...
+...
     },
-    "MP22": {
-      "supportedServers": [
-        "PAYARA_MICRO",
-        "LIBERTY",
-        "KUMULUZEE",
-        "THORNTAIL_V2"
-      ],
-      "specs": [
-        "CONFIG",
-        "FAULT_TOLERANCE",
-        "JWT_AUTH",
-        "METRICS",
-        "HEALTH_CHECKS",
-        "OPEN_API",
-        "OPEN_TRACING",
-        "REST_CLIENT"
-      ]
-    },
-  ...more MPxx removed for brevity...
-  },
-  "descriptions": {
-    "CONFIG": "Configuration - externalize and manage your configuration parameters outside your microservices",
-    "OPEN_API": "Open API - Generate OpenAPI-compliant API documentation for your microservices",
-    "HEALTH_CHECKS": "Health Checks - Verify the health of your microservices with custom verifications",
-    "REST_CLIENT": "Rest Client - Invoke RESTful services in a type-safe manner",
-    "FAULT_TOLERANCE": "Fault Tolerance - all about bulkheads, timeouts, circuit breakers, retries, etc. for your microservices",
-    "JWT_AUTH": "JWT Propagation - propagate security across your microservices",
-    "OPEN_TRACING": "Open Tracing - trace the flow of requests as they traverse your microservices",
-    "METRICS": "Metrics - Gather and create operational and business measurements for your microservices"
-  }
+    "descriptions": {
+        "CONFIG": "Configuration - externalize and manage your configuration parameters outside your microservices",
+        "OPEN_API": "Open API - Generate OpenAPI-compliant API documentation for your microservices",
+        "HEALTH_CHECKS": "Health Checks - Verify the health of your microservices with custom verifications",
+        "REST_CLIENT": "Rest Client - Invoke RESTful services in a type-safe manner",
+        "FAULT_TOLERANCE": "Fault Tolerance - all about bulkheads, timeouts, circuit breakers, retries, etc. for your microservices",
+        "JWT_AUTH": "JWT Propagation - propagate security across your microservices",
+        "OPEN_TRACING": "Open Tracing - trace the flow of requests as they traverse your microservices",
+        "METRICS": "Metrics - Gather and create operational and business measurements for your microservices"
+    }
 }
 ```
 
 Using value from ETag in If-None-Match:
 
 ```
-$ curl '-HIf-None-Match: "44730639"' -i https://start.microprofile.io/api/1/supportMatrix
+$ curl '-HIf-None-Match: "44730639"' -i https://start.microprofile.io/api/supportMatrix
 ...
 HTTP/1.1 304 Not Modified
 ```
@@ -322,129 +354,210 @@ HTTP/1.1 304 Not Modified
 ## Server implementations as keys
 
 ```
-$ curl -i https://start.microprofile.io/api/1/supportMatrix/servers
+$ curl -i https://start.microprofile.io/api/supportMatrix/servers
 ...
 ETag: "7b99230f"
 ...
 {
-  "configs": {
-    "PAYARA_MICRO": {
-      "MP21": [
-        "CONFIG",
-        "FAULT_TOLERANCE",
-        "JWT_AUTH",
-        "METRICS",
-        "HEALTH_CHECKS",
-        "OPEN_API",
-        "OPEN_TRACING",
-        "REST_CLIENT"
-      ],
-      "MP22": [
-        "CONFIG",
-        "FAULT_TOLERANCE",
-        "JWT_AUTH",
-        "METRICS",
-        "HEALTH_CHECKS",
-        "OPEN_API",
-        "OPEN_TRACING",
-        "REST_CLIENT"
-      ],
-      "MP12": [
-        "CONFIG",
-        "FAULT_TOLERANCE",
-        "JWT_AUTH",
-        "METRICS",
-        "HEALTH_CHECKS"
-      ],
-      "MP13": [
-        "CONFIG",
-        "FAULT_TOLERANCE",
-        "JWT_AUTH",
-        "METRICS",
-        "HEALTH_CHECKS",
-        "OPEN_API",
-        "OPEN_TRACING",
-        "REST_CLIENT"
-      ],
-      "MP14": [
-        "CONFIG",
-        "FAULT_TOLERANCE",
-        "JWT_AUTH",
-        "METRICS",
-        "HEALTH_CHECKS",
-        "OPEN_API",
-        "OPEN_TRACING",
-        "REST_CLIENT"
-      ],
-      "MP20": [
-        "CONFIG",
-        "FAULT_TOLERANCE",
-        "JWT_AUTH",
-        "METRICS",
-        "HEALTH_CHECKS",
-        "OPEN_API",
-        "OPEN_TRACING",
-        "REST_CLIENT"
-      ]
+    "configs": {
+        "LIBERTY": {
+            "MP14": [
+                "CONFIG",
+                "FAULT_TOLERANCE",
+                "JWT_AUTH",
+                "METRICS",
+                "HEALTH_CHECKS",
+                "OPEN_API",
+                "OPEN_TRACING",
+                "REST_CLIENT"
+            ],
+            "MP22": [
+                "CONFIG",
+                "FAULT_TOLERANCE",
+                "JWT_AUTH",
+                "METRICS",
+                "HEALTH_CHECKS",
+                "OPEN_API",
+                "OPEN_TRACING",
+                "REST_CLIENT"
+            ],
+            "MP30": [
+                "CONFIG",
+                "FAULT_TOLERANCE",
+                "JWT_AUTH",
+                "METRICS",
+                "HEALTH_CHECKS",
+                "OPEN_API",
+                "OPEN_TRACING",
+                "REST_CLIENT"
+            ],
+            "MP20": [
+                "CONFIG",
+                "FAULT_TOLERANCE",
+                "JWT_AUTH",
+                "METRICS",
+                "HEALTH_CHECKS",
+                "OPEN_API",
+                "OPEN_TRACING",
+                "REST_CLIENT"
+            ],
+            "MP21": [
+                "CONFIG",
+                "FAULT_TOLERANCE",
+                "JWT_AUTH",
+                "METRICS",
+                "HEALTH_CHECKS",
+                "OPEN_API",
+                "OPEN_TRACING",
+                "REST_CLIENT"
+            ],
+            "MP13": [
+                "CONFIG",
+                "FAULT_TOLERANCE",
+                "JWT_AUTH",
+                "METRICS",
+                "HEALTH_CHECKS",
+                "OPEN_API",
+                "OPEN_TRACING",
+                "REST_CLIENT"
+            ],
+            "MP12": [
+                "CONFIG",
+                "FAULT_TOLERANCE",
+                "JWT_AUTH",
+                "METRICS",
+                "HEALTH_CHECKS"
+            ]
+        },
+        "PAYARA_MICRO": {
+            "MP14": [
+                "CONFIG",
+                "FAULT_TOLERANCE",
+                "JWT_AUTH",
+                "METRICS",
+                "HEALTH_CHECKS",
+                "OPEN_API",
+                "OPEN_TRACING",
+                "REST_CLIENT"
+            ],
+            "MP22": [
+                "CONFIG",
+                "FAULT_TOLERANCE",
+                "JWT_AUTH",
+                "METRICS",
+                "HEALTH_CHECKS",
+                "OPEN_API",
+                "OPEN_TRACING",
+                "REST_CLIENT"
+            ],
+            "MP20": [
+                "CONFIG",
+                "FAULT_TOLERANCE",
+                "JWT_AUTH",
+                "METRICS",
+                "HEALTH_CHECKS",
+                "OPEN_API",
+                "OPEN_TRACING",
+                "REST_CLIENT"
+            ],
+            "MP21": [
+                "CONFIG",
+                "FAULT_TOLERANCE",
+                "JWT_AUTH",
+                "METRICS",
+                "HEALTH_CHECKS",
+                "OPEN_API",
+                "OPEN_TRACING",
+                "REST_CLIENT"
+            ],
+            "MP12": [
+                "CONFIG",
+                "FAULT_TOLERANCE",
+                "JWT_AUTH",
+                "METRICS",
+                "HEALTH_CHECKS"
+            ],
+            "MP13": [
+                "CONFIG",
+                "FAULT_TOLERANCE",
+                "JWT_AUTH",
+                "METRICS",
+                "HEALTH_CHECKS",
+                "OPEN_API",
+                "OPEN_TRACING",
+                "REST_CLIENT"
+            ]
+        },
+        "THORNTAIL_V2": {
+            "MP22": [
+                "CONFIG",
+                "FAULT_TOLERANCE",
+                "JWT_AUTH",
+                "METRICS",
+                "HEALTH_CHECKS",
+                "OPEN_API",
+                "OPEN_TRACING",
+                "REST_CLIENT"
+            ],
+            "MP30": [
+                "CONFIG",
+                "FAULT_TOLERANCE",
+                "JWT_AUTH",
+                "METRICS",
+                "HEALTH_CHECKS",
+                "OPEN_API",
+                "OPEN_TRACING",
+                "REST_CLIENT"
+            ],
+            "MP21": [
+                "CONFIG",
+                "FAULT_TOLERANCE",
+                "JWT_AUTH",
+                "METRICS",
+                "HEALTH_CHECKS",
+                "OPEN_API",
+                "OPEN_TRACING",
+                "REST_CLIENT"
+            ],
+            "MP12": [
+                "CONFIG",
+                "FAULT_TOLERANCE",
+                "JWT_AUTH",
+                "METRICS",
+                "HEALTH_CHECKS"
+            ],
+            "MP13": [
+                "CONFIG",
+                "FAULT_TOLERANCE",
+                "JWT_AUTH",
+                "METRICS",
+                "HEALTH_CHECKS",
+                "OPEN_API",
+                "OPEN_TRACING",
+                "REST_CLIENT"
+            ]
+        }
+...
+...other servers removed for brevity...
+...
     },
-    "THORNTAIL_V2": {
-      "MP21": [
-        "CONFIG",
-        "FAULT_TOLERANCE",
-        "JWT_AUTH",
-        "METRICS",
-        "HEALTH_CHECKS",
-        "OPEN_API",
-        "OPEN_TRACING",
-        "REST_CLIENT"
-      ],
-      "MP22": [
-        "CONFIG",
-        "FAULT_TOLERANCE",
-        "JWT_AUTH",
-        "METRICS",
-        "HEALTH_CHECKS",
-        "OPEN_API",
-        "OPEN_TRACING",
-        "REST_CLIENT"
-      ],
-      "MP12": [
-        "CONFIG",
-        "FAULT_TOLERANCE",
-        "JWT_AUTH",
-        "METRICS",
-        "HEALTH_CHECKS"
-      ],
-      "MP13": [
-        "CONFIG",
-        "FAULT_TOLERANCE",
-        "JWT_AUTH",
-        "METRICS",
-        "HEALTH_CHECKS",
-        "OPEN_API",
-        "OPEN_TRACING",
-        "REST_CLIENT"
-      ]
-    },
-...more servers removed for brevity...
-  },
-  "descriptions": {
-    "CONFIG": "Configuration - externalize and manage your configuration parameters outside your microservices",
-    "OPEN_API": "Open API - Generate OpenAPI-compliant API documentation for your microservices",
-    "HEALTH_CHECKS": "Health Checks - ensure your microservices is up and running by enabling health checks",
-    "REST_CLIENT": "Rest Client - Invoke RESTful services in a type-safe manner",
-    "FAULT_TOLERANCE": "Fault Tolerance - all about bulkheads, timeouts, circuit breakers, retries, etc. for your microservices",
-    "JWT_AUTH": "JWT Propagation - manage and propagate security across your microservices",
-    "OPEN_TRACING": "Open Tracing - trace the flow of requests as they traverse your microservices",
-    "METRICS": "Metrics - Gather and create operational and business measurements for your microservices"
-  }
+    "descriptions": {
+        "CONFIG": "Configuration - externalize and manage your configuration parameters outside your microservices",
+        "OPEN_API": "Open API - Generate OpenAPI-compliant API documentation for your microservices",
+        "HEALTH_CHECKS": "Health Checks - Verify the health of your microservices with custom verifications",
+        "REST_CLIENT": "Rest Client - Invoke RESTful services in a type-safe manner",
+        "FAULT_TOLERANCE": "Fault Tolerance - all about bulkheads, timeouts, circuit breakers, retries, etc. for your microservices",
+        "JWT_AUTH": "JWT Propagation - propagate security across your microservices",
+        "OPEN_TRACING": "Open Tracing - trace the flow of requests as they traverse your microservices",
+        "METRICS": "Metrics - Gather and create operational and business measurements for your microservices"
+    }
 }
 ```
 
 Using value from ETag in If-None-Match:
 
 ```
-$ curl '-HIf-None-Match: "7b99230f"' -i https://start.microprofile.io/api/1/supportMatrix/servers
+$ curl '-HIf-None-Match: "7b99230f"' -i https://start.microprofile.io/api/supportMatrix/servers
 ...
 HTTP/1.1 304 Not Modified
 ```


### PR DESCRIPTION
Fixes #237 

Introduces ```"selectAllSpecs":"true"``` (JSON) / ```selectAllSpecs=true``` (Query param) to
enable users to select all specs without enumerating them.

Adds new API version 3 (latest). Older API versions, 1 and 2, retain the legacy behaviour
when all examples were generated when no spec was selected.

Tested configurations, including mvn build, run examples, both single project (no specs sepected)
and service-a and service-b projects, with OpenJDK J9 11.0.5 Linux x86_64, Maven 3.6.0.

```
curl -O -J http://localhost:9090/api/project?supportedServer=HELIDON&artifactId=helidonnone
curl -O -J http://localhost:9090/api/project?supportedServer=HELIDON&selectAllSpecs=true&artifactId=helidonall
curl -O -J http://localhost:9090/api/project?supportedServer=HELIDON&selectedSpecs=JWT_AUTH&selectedSpecs=REST_CLIENT&selectedSpecs=OPEN_TRACING&artifactId=helidon
curl -O -J http://localhost:9090/api/project?supportedServer=THORNTAIL_V2&artifactId=thorntail_v2none
curl -O -J http://localhost:9090/api/project?supportedServer=THORNTAIL_V2&selectAllSpecs=true&artifactId=thorntail_v2all
curl -O -J http://localhost:9090/api/project?supportedServer=THORNTAIL_V2&selectedSpecs=JWT_AUTH&selectedSpecs=REST_CLIENT&selectedSpecs=OPEN_TRACING&artifactId=thorntail_v2
curl -O -J http://localhost:9090/api/project?supportedServer=LIBERTY&artifactId=libertynone
curl -O -J http://localhost:9090/api/project?supportedServer=LIBERTY&selectAllSpecs=true&artifactId=libertyall
curl -O -J http://localhost:9090/api/project?supportedServer=LIBERTY&selectedSpecs=JWT_AUTH&selectedSpecs=REST_CLIENT&selectedSpecs=OPEN_TRACING&artifactId=liberty
curl -O -J http://localhost:9090/api/project?supportedServer=KUMULUZEE&artifactId=kumuluzeenone
curl -O -J http://localhost:9090/api/project?supportedServer=KUMULUZEE&selectAllSpecs=true&artifactId=kumuluzeeall
curl -O -J http://localhost:9090/api/project?supportedServer=KUMULUZEE&selectedSpecs=JWT_AUTH&selectedSpecs=REST_CLIENT&selectedSpecs=OPEN_TRACING&artifactId=kumuluzee
curl -O -J http://localhost:9090/api/project?supportedServer=PAYARA_MICRO&artifactId=payara_micronone
curl -O -J http://localhost:9090/api/project?supportedServer=PAYARA_MICRO&selectAllSpecs=true&artifactId=payara_microall
curl -O -J http://localhost:9090/api/project?supportedServer=PAYARA_MICRO&selectedSpecs=JWT_AUTH&selectedSpecs=REST_CLIENT&selectedSpecs=OPEN_TRACING&artifactId=payara_micro
curl -O -J http://localhost:9090/api/project?supportedServer=TOMEE&artifactId=tomeenone
curl -O -J http://localhost:9090/api/project?supportedServer=TOMEE&selectAllSpecs=true&artifactId=tomeeall
curl -O -J http://localhost:9090/api/project?supportedServer=TOMEE&selectedSpecs=JWT_AUTH&selectedSpecs=REST_CLIENT&selectedSpecs=OPEN_TRACING&artifactId=tomee
```

Signed-off-by: Michal Karm Babacek <karm@fedoraproject.org>