### PR TITLE
Adds Integration Testsuite for all supported runtimes, upgrades some deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 executors:
   maven-builder:
     docker:
-    - image: circleci/openjdk:8u171-jdk
+    - image: circleci/openjdk:11-jdk
   docker-publisher:
     environment:
       IMAGE_NAME: microprofile/start.microprofile.io

--- a/Container/Dockerfile
+++ b/Container/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:7
 LABEL Author="Michal Karm Babacek <karm@redhat.com>"
-ENV JAVA_VERSION 1.8.0
-RUN yum install java-${JAVA_VERSION}-openjdk-headless -y && yum clean all && rm -rf /var/cache/yum /tmp/* && \
+ENV JAVA_VERSION 11
+RUN yum install java-${JAVA_VERSION}-openjdk -y && yum clean all && rm -rf /var/cache/yum /tmp/* && \
     useradd -s /sbin/nologin wildfly
 EXPOSE 8080/tcp
 USER wildfly

--- a/Container/Dockerfile.CI
+++ b/Container/Dockerfile.CI
@@ -5,8 +5,8 @@
 FROM centos:7 AS build-env
 LABEL Author="Michal Karm Babacek <karm@redhat.com>"
 WORKDIR /opt
-ENV MVN_VERSION  3.3.9
-ENV JAVA_VERSION 1.8.0
+ENV MVN_VERSION  3.6.0
+ENV JAVA_VERSION 11
 ENV M2_HOME /opt/apache-maven-${MVN_VERSION}
 ENV JAVA_HOME /usr/lib/jvm/jre-${JAVA_VERSION}-openjdk
 RUN yum install java-${JAVA_VERSION}-openjdk-devel unzip -y
@@ -24,8 +24,8 @@ RUN  ./apache-maven-${MVN_VERSION}/bin/mvn package -Pthorntail && \
 #############
 FROM centos:7
 LABEL Author="Michal Karm Babacek <karm@redhat.com>"
-ENV JAVA_VERSION 1.8.0
-RUN yum install java-${JAVA_VERSION}-openjdk-headless -y && yum clean all && \
+ENV JAVA_VERSION 11
+RUN yum install java-${JAVA_VERSION}-openjdk -y && yum clean all && \
     rm -rf /var/cache/yum /tmp/* && useradd -s /sbin/nologin wildfly
 EXPOSE 8080/tcp
 USER wildfly

--- a/pom.xml
+++ b/pom.xml
@@ -37,9 +37,9 @@
     <inceptionYear>2017</inceptionYear>
 
     <properties>
-        <version.thorntail>2.2.1.Final</version.thorntail>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <version.thorntail>2.5.0.Final</version.thorntail>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.exec.plugin.version>1.6.0</maven.exec.plugin.version>
 
         <failOnMissingWebXml>false</failOnMissingWebXml>
@@ -51,6 +51,7 @@
         <primefaces.version>7.0</primefaces.version>
         <thymeleaf.version>3.0.10.RELEASE</thymeleaf.version>
         <junit.version>4.12</junit.version>
+        <resteasy.version>4.3.0.Final</resteasy.version>
 
         <checkstyle.version>2.17</checkstyle.version>
         <checkstyle.methodNameFormat>^_?[a-z][a-zA-Z0-9]*$</checkstyle.methodNameFormat>
@@ -95,12 +96,6 @@
             <version>${thymeleaf.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>
@@ -221,16 +216,73 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <executable>${basedir}/version.txt.sh</executable>
+                    <executable>${basedir}/version.txt.${script.extension}</executable>
                     <workingDirectory>${basedir}/target/classes/</workingDirectory>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.0.0-M3</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>add-integration-test-source-as-test-sources</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/it/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>
 
     <profiles>
         <profile>
+            <id>Windows</id>
+            <activation>
+                <os>
+                    <family>Windows</family>
+                </os>
+            </activation>
+            <properties>
+                <script.extension>bat</script.extension>
+            </properties>
+        </profile>
+        <profile>
+            <id>unix</id>
+            <activation>
+                <os>
+                    <family>unix</family>
+                </os>
+            </activation>
+            <properties>
+                <script.extension>sh</script.extension>
+            </properties>
+        </profile>
+        <profile>
             <id>thorntail</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
             <dependencies>
                 <dependency>
                     <groupId>io.thorntail</groupId>
@@ -247,16 +299,36 @@
                     <artifactId>jaxrs</artifactId>
                 </dependency>
 
+                <dependency>
+                    <groupId>org.jboss.resteasy</groupId>
+                    <artifactId>resteasy-client</artifactId>
+                    <version>${resteasy.version}</version>
+                    <scope>test</scope>
+                </dependency>
+
+                <dependency>
+                    <groupId>io.thorntail</groupId>
+                    <artifactId>arquillian</artifactId>
+                    <scope>test</scope>
+                </dependency>
+
+                <dependency>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                    <version>${junit.version}</version>
+                    <scope>test</scope>
+                </dependency>
+
             </dependencies>
 
             <dependencyManagement>
                 <dependencies>
                     <dependency>
                         <groupId>io.thorntail</groupId>
-                        <artifactId>bom-all</artifactId>
+                        <artifactId>bom</artifactId>
                         <version>${version.thorntail}</version>
-                        <scope>import</scope>
                         <type>pom</type>
+                        <scope>import</scope>
                     </dependency>
                 </dependencies>
             </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <inceptionYear>2017</inceptionYear>
 
     <properties>
-        <version.thorntail>2.5.0.Final</version.thorntail>
+        <version.thorntail>2.6.0.Final</version.thorntail>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <maven.exec.plugin.version>1.6.0</maven.exec.plugin.version>
@@ -94,6 +94,13 @@
             <groupId>org.thymeleaf</groupId>
             <artifactId>thymeleaf</artifactId>
             <version>${thymeleaf.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/src/it/README.md
+++ b/src/it/README.md
@@ -50,9 +50,9 @@ Last but not least, build and runtime logs are checked for errors. See Whitelist
 
 At the very end of the execution, application(s) are terminated. There is also a loop that waits for a TCP socket to die.
 # Platforms
-The TS was tested on OenJDK Java 11 J9, on Linux. It is aiming at being portable to Windows, e.g. ```powershell``` is used
-instead of ```unzip``` and ```taskkill``` instead of ```kill```, but it was not tested on Windows yet. If you are running the TS on Mac,
-make sure your ```unzip``` can work with the arguments TS supplies or open a PR.
+The TS was tested on OpenJDK Java 11 J9 and HotSpot on Linux and with OpenJDK 11 HotSpot on Windows. With Windows,  ```powershell``` is used
+instead of ```unzip``` and ```taskkill``` instead of ```kill```. There is also some ```wmic``` heuristics to clean hanging processes.
+If you are running the TS on Mac, make sure your ```unzip``` can work with the arguments TS supplies or open a PR.
 
 # Logging and logs
 All logs are archived in ```target/archived-logs```. If a build or a server runtime fails, 
@@ -84,6 +84,10 @@ Run some tests for a specific runtime only:
 Debug a single test:
 
     mvn -DfoforkCount=0 -Dmaven.surefire.debug clean verify -Pthorntail -Dtest=TestMatrixTest#tomeeAll -Dskip.integration.tests=false -DSTARTER_TS_WORKSPACE=/dev/shm/
+    
+Starting on Windows, e.g.:
+
+    mvn clean verify -Pthorntail -Dskip.integration.tests=false -DSTARTER_TS_WORKSPACE=C:\tmp\
 
 Note that if you don't specify STARTER_TS_WORKSPACE, the fallback is whatever ```java.io.tmpdir``` returns on your system.
 

--- a/src/it/README.md
+++ b/src/it/README.md
@@ -1,0 +1,90 @@
+# Test suite
+
+All tests are contained in a one class called TestMatrixTest, each server runtime
+has 4 identical test cases (with special tweaks only for Tomee), e.g. with Thorntail it is:
+
+    public void thorntailEmpty() {
+        testRuntime("THORNTAIL_V2", "thorntail",
+                SpecSelection.EMPTY, new int[]{9990});
+    }
+
+    public void thorntailAll() {
+        testRuntime("THORNTAIL_V2", "thorntail",
+                SpecSelection.ALL, new int[]{9990, 8180, 10090});
+    }
+
+    public void thorntailAllButJWTRest() {
+        testRuntime("THORNTAIL_V2", "thorntail",
+                SpecSelection.ALL_BUT_JWT_REST, new int[]{9990});
+    }
+
+    public void thorntailJWTRest() {
+        testRuntime("THORNTAIL_V2", "thorntail",
+                SpecSelection.JWT_REST, new int[]{9990, 8180, 10090});
+    }
+
+ * Empty test case does not select any examples, so only the default HelloWorld endpoint is tested.
+ * All selects all examples and tests them all (expect for Open Tracing as Jaeger is on TODO list).
+ * AllButJWTRest selects and tests all but JWT and REST; the main purpose is to ensure that no service-a/service-b division takes place.
+ * JWTRest selects and tests only JWT and REST.
+ 
+ Those additional ports are for the final cleanup after test, for a loop that awaits socket closure.
+ The main landing application port is parsed from README file, but there are other auxiliary ports that had to be hardcoded here.
+ 
+# How does it work
+REST API is used to download a zip. The zip file is unzipped.
+README file(s) are parsed to get the first mvn command,
+which is assumed to be the build one. The first java command from README is assumed to be the one to run the server.
+Multiple flavours of builds, i.e. multiple ways to build the application is an unsupported feature in the TS at the moment.
+Landing page address is also parsed from the README file as the first one beginning with http://.
+
+
+Build commands are used to build the generated project(s). If you have never run the TS, this might take a long time. Mind
+you are downloading all dependencies for THORNTAIL_V2, PAYARA_MICRO, LIBERTY, HELIDON, KUMULUZEE and TOMEE.
+
+Run commands are then used to run the application(s).
+
+A loop awaits them to be available and then each spec is tested, see MPSpec enum for definitions of expected content.
+
+Last but not least, build and runtime logs are checked for errors. See Whitelist enum for whitelisting known and expected error messages.
+
+At the very end of the execution, application(s) are terminated. There is also a loop that waits for a TCP socket to die.
+# Platforms
+The TS was tested on OenJDK Java 11 J9, on Linux. It is aiming at being portable to Windows, e.g. ```powershell``` is used
+instead of ```unzip``` and ```taskkill``` instead of ```kill```, but it was not tested on Windows yet. If you are running the TS on Mac,
+make sure your ```unzip``` can work with the arguments TS supplies or open a PR.
+
+# Logging and logs
+All logs are archived in ```target/archived-logs```. If a build or a server runtime fails, 
+this is the first place to look for clues. Both maven build logs and runtime logs are archived. Unzip log is archived too.
+
+## Whitelisting errors
+See Whitelist enum for currently whitelisted errors per each server runtime.
+Examples from the TS execution:
+
+Kumuluzee:
+```
+Jan 17, 2020 4:14:44 PM org.eclipse.microprofile.starter.utils.Logs checkLog
+INFO: Build log for kumuluzeeAllButJWTRest contains whitelisted error: 
+  `[INFO] Copying error_prone_annotations-2.2.0.jar to /dev/shm/kumuluzee/target/classes/lib/error_prone_annotations-2.2.0.jar'
+```
+Open Liberty:
+```
+Jan 17, 2020 11:21:21 AM org.eclipse.microprofile.starter.utils.Logs checkLog
+INFO: Runtime log for libertyEmpty contains whitelisted error: 
+  `[ERROR   ] CWMOT0008E: OpenTracing cannot track JAX-RS requests because an OpentracingTracerFactory class was not provided.'
+```
+
+# Running the TS
+
+Run some tests for a specific runtime only:
+
+    mvn clean verify -Pthorntail -Dtest=TestMatrixTest#tomee* -Dskip.integration.tests=false -DSTARTER_TS_WORKSPACE=/dev/shm/
+    
+Debug a single test:
+
+    mvn -DfoforkCount=0 -Dmaven.surefire.debug clean verify -Pthorntail -Dtest=TestMatrixTest#tomeeAll -Dskip.integration.tests=false -DSTARTER_TS_WORKSPACE=/dev/shm/
+
+Note that if you don't specify STARTER_TS_WORKSPACE, the fallback is whatever ```java.io.tmpdir``` returns on your system.
+
+Happy testing.

--- a/src/it/README.md
+++ b/src/it/README.md
@@ -50,9 +50,8 @@ Last but not least, build and runtime logs are checked for errors. See Whitelist
 
 At the very end of the execution, application(s) are terminated. There is also a loop that waits for a TCP socket to die.
 # Platforms
-The TS was tested on OpenJDK Java 11 J9 and HotSpot on Linux and with OpenJDK 11 HotSpot on Windows. With Windows,  ```powershell``` is used
+The TS was tested on OpenJDK Java 11 J9 and HotSpot on Linux and with OpenJDK 11 HotSpot on Windows. It also works on Mac OS. With Windows,  ```powershell``` is used
 instead of ```unzip``` and ```taskkill``` instead of ```kill```. There is also some ```wmic``` heuristics to clean hanging processes.
-If you are running the TS on Mac, make sure your ```unzip``` can work with the arguments TS supplies or open a PR.
 
 # Logging and logs
 All logs are archived in ```target/archived-logs```. If a build or a server runtime fails, 

--- a/src/it/java/org/eclipse/microprofile/starter/TestMatrixTest.java
+++ b/src/it/java/org/eclipse/microprofile/starter/TestMatrixTest.java
@@ -1,0 +1,448 @@
+/*
+ * Copyright (c) 2017-2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.eclipse.microprofile.starter;
+
+import org.eclipse.microprofile.starter.utils.Commands;
+import org.eclipse.microprofile.starter.utils.MPSpec;
+import org.eclipse.microprofile.starter.utils.SpecSelection;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.arquillian.DefaultDeployment;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+import static org.eclipse.microprofile.starter.utils.Commands.cleanWorkspace;
+import static org.eclipse.microprofile.starter.utils.Commands.download;
+import static org.eclipse.microprofile.starter.utils.Commands.getWorkspaceDir;
+import static org.eclipse.microprofile.starter.utils.Commands.processStopper;
+import static org.eclipse.microprofile.starter.utils.Commands.runCommand;
+import static org.eclipse.microprofile.starter.utils.Commands.unzip;
+import static org.eclipse.microprofile.starter.utils.Logs.S;
+import static org.eclipse.microprofile.starter.utils.Logs.archiveLog;
+import static org.eclipse.microprofile.starter.utils.Logs.checkLog;
+import static org.eclipse.microprofile.starter.utils.ReadmeParser.parseReadme;
+import static org.eclipse.microprofile.starter.utils.WebpageTester.testWeb;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * MicroProfile Starter runtimes servers smoke tests.
+ *
+ * The goal is to make sure all our runtimes can be built and run without errors
+ * and that the example applications show expected outputs.
+ *
+ * @author Michal Karm Babacek <karm@redhat.com>
+ */
+@RunWith(Arquillian.class)
+@DefaultDeployment(type = DefaultDeployment.Type.WAR)
+public class TestMatrixTest {
+
+    private static final Logger LOGGER = Logger.getLogger(TestMatrixTest.class.getName());
+
+    public static final String TMP = getWorkspaceDir();
+
+    public static final String API_URL = "http://127.0.0.1:9090/api";
+    final Client client = ClientBuilder.newBuilder().build();
+
+    WebTarget target;
+
+    @Rule
+    public TestName testName = new TestName();
+
+    @Before
+    public void before() {
+        target = client.target(API_URL);
+    }
+
+    public void testRuntime(String supportedServer, String artifactId, SpecSelection specSelection, int[] additionalPotsToCheck) throws IOException, InterruptedException {
+        LOGGER.info("Testing server: " + supportedServer + ", config: " + specSelection.toString());
+
+        Process pB = null;
+        Process pA = null;
+        File unzipLog = null;
+        File buildLogA = null;
+        File buildLogB = null;
+        File runLogA = null;
+        File runLogB = null;
+
+        try {
+            // Cleanup
+            cleanWorkspace(artifactId);
+
+            // Download
+            LOGGER.info("Downloading...");
+            String location = TMP + S + artifactId + ".zip";
+            download(client, supportedServer, artifactId, specSelection, location);
+
+            // Unzip
+            unzipLog = unzip(location, artifactId);
+
+            // Parse README
+            File directoryA = null;
+            File directoryB = null;
+            String[][] buildCmdRunCmd = null;
+            if (specSelection.hasServiceB) {
+                directoryA = new File(TMP + S + artifactId + S + "service-a" + S);
+                directoryB = new File(TMP + S + artifactId + S + "service-b" + S);
+                File readmeB = new File(directoryB, "readme.md");
+                buildCmdRunCmd = parseReadme(readmeB, false);
+            } else {
+                directoryA = new File(TMP + S + artifactId + S);
+            }
+            File readmeA = new File(directoryA, "readme.md");
+            String[][] buildCmdRunCmdWebAddr = parseReadme(readmeA, true);
+
+            // Build
+            LOGGER.info("Build might take many minutes if the whole Internet is being downloaded.");
+            buildLogA = new File(directoryA.getAbsolutePath() + S + directoryA.getName() + "-build.log");
+            if (specSelection.hasServiceB) {
+                buildLogB = new File(directoryB.getAbsolutePath() + S + directoryB.getName() + "-build.log");
+            }
+            ExecutorService buildService = Executors.newFixedThreadPool(2);
+            buildService.submit(new Commands.ProcessRunner(directoryA, buildLogA, buildCmdRunCmdWebAddr[0], 20));
+            if (specSelection.hasServiceB) {
+                buildService.submit(new Commands.ProcessRunner(directoryB, buildLogB, buildCmdRunCmd[0], 20));
+            }
+            buildService.shutdown();
+            buildService.awaitTermination(30, TimeUnit.MINUTES);
+
+            assertTrue(buildLogA.exists());
+            checkLog(this.getClass().getCanonicalName(), testName.getMethodName(), "Build log", buildLogA);
+            if (specSelection.hasServiceB) {
+                assertTrue(buildLogB.exists());
+                checkLog(this.getClass().getCanonicalName(), testName.getMethodName(), "Build log", buildLogB);
+            }
+
+            // Run Service A (and Service B)
+            LOGGER.info("Running...");
+            runLogA = new File(directoryA.getAbsolutePath() + S + directoryA.getName() + "-run.log");
+            pA = runCommand(buildCmdRunCmdWebAddr[1], directoryA, runLogA);
+            if (specSelection.hasServiceB) {
+                runLogB = new File(directoryB.getAbsolutePath() + S + directoryB.getName() + "-run.log");
+                pB = runCommand(buildCmdRunCmd[1], directoryB, runLogB);
+            }
+
+            // Test web pages
+            LOGGER.info("Testing web page content...");
+            String homePage = buildCmdRunCmdWebAddr[2][0];
+            String urlBase = homePage.replace("index.html", "");
+            // First landing page
+            testWeb(homePage, 60, "MicroProfile");
+            // Tomee has a special case of prepending context
+            String c = (supportedServer.equalsIgnoreCase("TOMEE") ? "data/" : "");
+            // Spec by spec test
+            if (specSelection == SpecSelection.EMPTY) {
+                // Verify that links are present on the index.html page
+                testWeb(homePage, 10, MPSpec.DEFAULT.urlContent[0][0]);
+                // Verify content
+                testWeb(urlBase + MPSpec.DEFAULT.urlContent[0][0], 5, MPSpec.DEFAULT.urlContent[0][1]);
+            } else if (specSelection == SpecSelection.ALL) {
+                // Verify content
+                testWeb(urlBase + MPSpec.DEFAULT.urlContent[0][0], 5, MPSpec.DEFAULT.urlContent[0][1]);
+                testWeb(urlBase + MPSpec.CONFIG.urlContent[0][0], 5, MPSpec.CONFIG.urlContent[0][1]);
+                testWeb(urlBase + MPSpec.CONFIG.urlContent[1][0], 5, MPSpec.CONFIG.urlContent[1][1]);
+                testWeb(urlBase + MPSpec.FAULT_TOLERANCE.urlContent[0][0], 5, MPSpec.FAULT_TOLERANCE.urlContent[0][1]);
+                testWeb(urlBase + c + MPSpec.HEALTH_CHECKS.urlContent[0][0], 5, MPSpec.HEALTH_CHECKS.urlContent[0][1]);
+                testWeb(urlBase + MPSpec.METRICS.urlContent[0][0], 5, MPSpec.METRICS.urlContent[0][1]);
+                testWeb(urlBase + c + MPSpec.METRICS.urlContent[1][0], 10, MPSpec.METRICS.urlContent[1][1]);
+                testWeb(urlBase + MPSpec.JWT_AUTH.urlContent[0][0], 5, MPSpec.JWT_AUTH.urlContent[0][1]);
+                testWeb(urlBase + c + MPSpec.OPEN_API.urlContent[0][0], 5, MPSpec.OPEN_API.urlContent[0][1]);
+                testWeb(urlBase + MPSpec.REST_CLIENT.urlContent[0][0], 5, MPSpec.REST_CLIENT.urlContent[0][1]);
+            } else if (specSelection == SpecSelection.ALL_BUT_JWT_REST) {
+                // Verify content
+                testWeb(urlBase + MPSpec.DEFAULT.urlContent[0][0], 5, MPSpec.DEFAULT.urlContent[0][1]);
+                testWeb(urlBase + MPSpec.CONFIG.urlContent[0][0], 5, MPSpec.CONFIG.urlContent[0][1]);
+                testWeb(urlBase + MPSpec.CONFIG.urlContent[1][0], 5, MPSpec.CONFIG.urlContent[1][1]);
+                testWeb(urlBase + MPSpec.FAULT_TOLERANCE.urlContent[0][0], 5, MPSpec.FAULT_TOLERANCE.urlContent[0][1]);
+                testWeb(urlBase + c + MPSpec.HEALTH_CHECKS.urlContent[0][0], 5, MPSpec.HEALTH_CHECKS.urlContent[0][1]);
+                testWeb(urlBase + MPSpec.METRICS.urlContent[0][0], 5, MPSpec.METRICS.urlContent[0][1]);
+                testWeb(urlBase + c + MPSpec.METRICS.urlContent[1][0], 5, MPSpec.METRICS.urlContent[1][1]);
+                testWeb(urlBase + c + MPSpec.OPEN_API.urlContent[0][0], 5, MPSpec.OPEN_API.urlContent[0][1]);
+            } else if (specSelection == SpecSelection.JWT_REST) {
+                // Verify content
+                testWeb(urlBase + MPSpec.DEFAULT.urlContent[0][0], 5, MPSpec.DEFAULT.urlContent[0][1]);
+                testWeb(urlBase + MPSpec.JWT_AUTH.urlContent[0][0], 5, MPSpec.JWT_AUTH.urlContent[0][1]);
+                testWeb(urlBase + MPSpec.REST_CLIENT.urlContent[0][0], 5, MPSpec.REST_CLIENT.urlContent[0][1]);
+            } else {
+                throw new IllegalArgumentException(
+                        "Unexpected SpecSelection enum value. Have you updated SpecSelection?");
+            }
+
+            LOGGER.info("Terminate and scan logs...");
+            // This is a move that makes it flush on my Linux x86_64 OpenJDK J9/HotSpot 11. Does no harm on Win.
+            int bytes = pA.getInputStream().available();
+            if (specSelection.hasServiceB) {
+                bytes = pB.getInputStream().available();
+            }
+
+            processStopper(pA, artifactId);
+            if (specSelection.hasServiceB) {
+                processStopper(pB, artifactId);
+            }
+
+            checkLog(this.getClass().getCanonicalName(), testName.getMethodName(), "Runtime log", runLogA);
+            if (specSelection.hasServiceB) {
+                checkLog(this.getClass().getCanonicalName(), testName.getMethodName(), "Runtime log", runLogB);
+            }
+            LOGGER.info("Gonna wait for ports closed...");
+            // Release ports
+            Commands.waitForTcpClosed("localhost", Commands.parsePort(urlBase), 60);
+            if (additionalPotsToCheck != null) {
+                for (int port : additionalPotsToCheck) {
+                    Commands.waitForTcpClosed("localhost", port, 30);
+                }
+            }
+        } finally {
+            client.close();
+            // Make sure processes are down even if there was an exception / failure
+            if (pA != null) {
+                processStopper(pA, artifactId);
+
+            }
+            if (specSelection.hasServiceB && pB != null) {
+                processStopper(pB, artifactId);
+            }
+            // Archive logs no matter what
+            archiveLog(this.getClass().getCanonicalName(), testName.getMethodName(), unzipLog);
+            archiveLog(this.getClass().getCanonicalName(), testName.getMethodName(), buildLogA);
+            archiveLog(this.getClass().getCanonicalName(), testName.getMethodName(), runLogA);
+            if (specSelection.hasServiceB) {
+                archiveLog(this.getClass().getCanonicalName(), testName.getMethodName(), buildLogB);
+                archiveLog(this.getClass().getCanonicalName(), testName.getMethodName(), runLogB);
+            }
+            cleanWorkspace(artifactId);
+        }
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(0)
+    public void apiAccessibleSanity() {
+        Response response = target.request().get();
+        assertEquals("MicroProfile Starter REST API should be available", Response.Status.OK.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(1)
+    public void thorntailEmpty() throws IOException, InterruptedException {
+        testRuntime("THORNTAIL_V2", "thorntail",
+                SpecSelection.EMPTY, new int[]{9990});
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(2)
+    public void thorntailAll() throws IOException, InterruptedException {
+        testRuntime("THORNTAIL_V2", "thorntail",
+                SpecSelection.ALL, new int[]{9990, 8180, 10090});
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(3)
+    public void thorntailAllButJWTRest() throws IOException, InterruptedException {
+        testRuntime("THORNTAIL_V2", "thorntail",
+                SpecSelection.ALL_BUT_JWT_REST, new int[]{9990});
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(4)
+    public void thorntailJWTRest() throws IOException, InterruptedException {
+        testRuntime("THORNTAIL_V2", "thorntail",
+                SpecSelection.JWT_REST, new int[]{9990, 8180, 10090});
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(5)
+    public void payaraEmpty() throws IOException, InterruptedException {
+        testRuntime("PAYARA_MICRO", "payara",
+                SpecSelection.EMPTY, new int[]{6900});
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(6)
+    public void payaraAll() throws IOException, InterruptedException {
+        testRuntime("PAYARA_MICRO", "payara",
+                SpecSelection.ALL, new int[]{6900, 6901, 8180});
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(7)
+    public void payaraAllButJWTRest() throws IOException, InterruptedException {
+        testRuntime("PAYARA_MICRO", "payara",
+                SpecSelection.ALL_BUT_JWT_REST, new int[]{6900});
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(8)
+    public void payaraJWTRest() throws IOException, InterruptedException {
+        testRuntime("PAYARA_MICRO", "payara",
+                SpecSelection.JWT_REST, new int[]{6900, 6901, 8180});
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(9)
+    public void libertyEmpty() throws IOException, InterruptedException {
+        testRuntime("LIBERTY", "liberty",
+                SpecSelection.EMPTY, new int[]{8181, 9080, 8543, 9443});
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(10)
+    public void libertyAll() throws IOException, InterruptedException {
+        testRuntime("LIBERTY", "liberty",
+                SpecSelection.ALL, new int[]{8181, 9080, 8543, 9443, 9444, 8281, 9081});
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(11)
+    public void libertyAllButJWTRest() throws IOException, InterruptedException {
+        testRuntime("LIBERTY", "liberty",
+                SpecSelection.ALL_BUT_JWT_REST, new int[]{8181, 9080, 8543, 9443});
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(12)
+    public void libertyJWTRest() throws IOException, InterruptedException {
+        testRuntime("LIBERTY", "liberty",
+                SpecSelection.JWT_REST, new int[]{8181, 9080, 8543, 9443, 9444, 8281, 9081});
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(13)
+    public void helidonEmpty() throws IOException, InterruptedException {
+        testRuntime("HELIDON", "helidon",
+                SpecSelection.EMPTY, new int[]{});
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(14)
+    public void helidonAll() throws IOException, InterruptedException {
+        testRuntime("HELIDON", "helidon",
+                SpecSelection.ALL, new int[]{8180});
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(15)
+    public void helidonAllButJWTRest() throws IOException, InterruptedException {
+        testRuntime("HELIDON", "helidon",
+                SpecSelection.ALL_BUT_JWT_REST, new int[]{});
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(16)
+    public void helidonJWTRest() throws IOException, InterruptedException {
+        testRuntime("HELIDON", "helidon",
+                SpecSelection.JWT_REST, new int[]{8180});
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(17)
+    public void kumuluzeeEmpty() throws IOException, InterruptedException {
+        testRuntime("KUMULUZEE", "kumuluzee",
+                SpecSelection.EMPTY, new int[]{});
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(18)
+    public void kumuluzeeAll() throws IOException, InterruptedException {
+        testRuntime("KUMULUZEE", "kumuluzee",
+                SpecSelection.ALL, new int[]{8180});
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(19)
+    public void kumuluzeeAllButJWTRest() throws IOException, InterruptedException {
+        testRuntime("KUMULUZEE", "kumuluzee",
+                SpecSelection.ALL_BUT_JWT_REST, new int[]{});
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(20)
+    public void kumuluzeeJWTRest() throws IOException, InterruptedException {
+        testRuntime("KUMULUZEE", "kumuluzee",
+                SpecSelection.JWT_REST, new int[]{8180});
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(21)
+    public void tomeeEmpty() throws IOException, InterruptedException {
+        testRuntime("TOMEE", "tomee",
+                SpecSelection.EMPTY, new int[]{8009, 8005});
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(22)
+    public void tomeeAll() throws IOException, InterruptedException {
+        testRuntime("TOMEE", "tomee",
+                SpecSelection.ALL, new int[]{8009, 8005, 8180, 8109, 8105});
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(23)
+    public void tomeeAllButJWTRest() throws IOException, InterruptedException {
+        testRuntime("TOMEE", "tomee",
+                SpecSelection.ALL_BUT_JWT_REST, new int[]{8009, 8005});
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(24)
+    public void tomeeJWTRest() throws IOException, InterruptedException {
+        testRuntime("TOMEE", "tomee",
+                SpecSelection.JWT_REST, new int[]{8009, 8005, 8180, 8109, 8105});
+    }
+}

--- a/src/it/java/org/eclipse/microprofile/starter/utils/Commands.java
+++ b/src/it/java/org/eclipse/microprofile/starter/utils/Commands.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright (c) 2017-2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.eclipse.microprofile.starter.utils;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.Response;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+import static org.eclipse.microprofile.starter.TestMatrixTest.API_URL;
+import static org.eclipse.microprofile.starter.TestMatrixTest.TMP;
+import static org.eclipse.microprofile.starter.utils.Logs.S;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Michal Karm Babacek <karm@redhat.com>
+ */
+public class Commands {
+    private static final Logger LOGGER = Logger.getLogger(Commands.class.getName());
+
+    private static final String STARTER_TS_WORKSPACE = "STARTER_TS_WORKSPACE";
+
+    public static String getWorkspaceDir() {
+        String env = System.getenv().get(STARTER_TS_WORKSPACE);
+        String sys = System.getProperty(STARTER_TS_WORKSPACE);
+        String fallback = System.getProperty("java.io.tmpdir");
+        if (StringUtils.isNotBlank(env)) {
+            return env;
+        }
+        if (StringUtils.isNotBlank(sys)) {
+            return sys;
+        }
+        return fallback;
+    }
+
+    public static void download(Client client, String supportedServer, String artifactId, SpecSelection specSelection, String location) {
+        Response response = client.target(API_URL + "/project?supportedServer=" + supportedServer + specSelection.queryParam + "&artifactId=" + artifactId).request().get();
+        assertEquals("Download failed.", Response.Status.OK.getStatusCode(), response.getStatus());
+        try (FileOutputStream out = new FileOutputStream(location); InputStream in = (InputStream) response.getEntity()) {
+            in.transferTo(out);
+            out.flush();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static File unzip(String location, String artifactId) throws InterruptedException, IOException {
+        ProcessBuilder pb;
+        if (isThisWindows()) {
+            pb = new ProcessBuilder("powershell", "-c", "Expand-Archive", "-Path", location, "-DestinationPath", TMP, "-Force");
+        } else {
+            pb = new ProcessBuilder("unzip", "-o", location, "-d", TMP);
+        }
+        Map<String, String> env = pb.environment();
+        env.put("PATH", System.getenv("PATH"));
+        pb.directory(new File(TMP));
+        File unzipLog = new File(TMP + S + artifactId + "-unzip.log");
+        pb.redirectErrorStream(true);
+        pb.redirectOutput(ProcessBuilder.Redirect.to(unzipLog));
+        Process p = pb.start();
+        // On slow cloud VMs with weird I/O, this could be minutes for some reason...
+        p.waitFor(3, TimeUnit.MINUTES);
+        return unzipLog;
+    }
+
+    public static void cleanWorkspace(String artifactId) {
+        String path = TMP + S + artifactId;
+        try {
+            FileUtils.deleteDirectory(new File(path));
+        } catch (IOException e) {
+            // Silence is golden
+        }
+        (new File(path + ".zip")).deleteOnExit();
+        (new File(path + "-unzip.log")).deleteOnExit();
+        (new File(path + ".zip")).delete();
+        (new File(path + "-unzip.log")).delete();
+    }
+
+    public static boolean waitForTcpClosed(String host, int port, long loopTimeoutS) throws InterruptedException, UnknownHostException {
+        InetAddress address = InetAddress.getByName(host);
+        long now = System.currentTimeMillis();
+        long startTime = now;
+        InetSocketAddress socketAddr = new InetSocketAddress(address, port);
+        while (now - startTime < 1000 * loopTimeoutS) {
+            try (Socket socket = new Socket()) {
+                // If it let's you write something there, it is still ready.
+                socket.connect(socketAddr, 1000);
+                socket.setSendBufferSize(1);
+                socket.getOutputStream().write(1);
+                socket.shutdownInput();
+                socket.shutdownOutput();
+                LOGGER.info("Socket still available: " + host + ":" + port);
+            } catch (IOException e) {
+                // Exception thrown - socket is likely closed.
+                return true;
+            }
+            Thread.sleep(1000);
+            now = System.currentTimeMillis();
+        }
+        return false;
+    }
+
+    public static int parsePort(String url) {
+        return Integer.parseInt(url.split(":")[2].split("/")[0]);
+    }
+
+    public static Process runCommand(String[] command, File directory, File logFile) {
+        ProcessBuilder pa;
+        if (isThisWindows()) {
+            pa = new ProcessBuilder(ArrayUtils.addAll(new String[]{"cmd", "/C"}, command));
+        } else {
+            pa = new ProcessBuilder(ArrayUtils.addAll(command));
+        }
+        Map<String, String> envA = pa.environment();
+        envA.put("PATH", System.getenv("PATH"));
+        pa.directory(directory);
+        pa.redirectErrorStream(true);
+        pa.redirectOutput(ProcessBuilder.Redirect.to(logFile));
+        Process pA = null;
+        try {
+            pA = pa.start();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return pA;
+    }
+
+    public static void pidKiller(long pid) {
+        try {
+            // TODO: /F is actually -9, so we are more strict on Windows. Good/no good?
+            if (isThisWindows()) {
+                Runtime.getRuntime().exec(new String[]{"cmd", "/C", "taskkill", "/PID", Long.toString(pid), "/F", "/T"});
+            } else {
+                Runtime.getRuntime().exec(new String[]{"kill", "-15", Long.toString(pid)});
+            }
+        } catch (IOException e) {
+            LOGGER.severe(e.getMessage());
+        }
+    }
+
+    public static void processStopper(Process p, String artifactId) throws InterruptedException, IOException {
+        // Unlike all others, Tomee creates a child :-)
+        p.children().forEach(child -> {
+            child.destroy();
+            pidKiller(child.pid());
+        });
+        p.destroy();
+        p.waitFor(3, TimeUnit.MINUTES);
+        pidKiller(p.pid());
+        if (isThisWindows()) {
+            windowsCmdCleaner(artifactId);
+        }
+    }
+
+    public static void windowsCmdCleaner(String artifactId) throws IOException, InterruptedException {
+        List<Long> pidsToKill = new ArrayList<>(2);
+        String[] wmicPIDcmd = new String[]{
+                "wmic", "process", "where", "(",
+                "commandline", "like", "\"%\\\\" + artifactId + "\\\\%\"", "and", "name", "=", "\"java.exe\"", "and",
+                "not", "commandline", "like", "\"%wmic%\"", "and",
+                "not", "commandline", "like", "\"%maven%\"",
+                ")", "get", "Processid", "/format:list"};
+        ProcessBuilder pbA = new ProcessBuilder(wmicPIDcmd);
+        pbA.redirectErrorStream(true);
+        Process p = pbA.start();
+        try (BufferedReader processOutputReader = new BufferedReader(new InputStreamReader(p.getInputStream()))) {
+            String l;
+            while ((l = processOutputReader.readLine()) != null) {
+                if (l.contains("ProcessId=")) {
+                    try {
+                        pidsToKill.add(Long.parseLong(l.split("=")[1].trim()));
+                    } catch (NumberFormatException ex) {
+                        //Silence is golden. We don't care about wmic output glitches. This is a best effort.
+                    }
+                }
+            }
+            p.waitFor();
+        }
+        if (pidsToKill.isEmpty()) {
+            LOGGER.warning("wmic didn't find any additional PIDs to kill.");
+        } else {
+            LOGGER.info(String.format("wmic found %d additional pids to kill", pidsToKill.size()));
+        }
+        pidsToKill.forEach(Commands::pidKiller);
+    }
+
+    public static boolean isThisWindows() {
+        return System.getProperty("os.name").matches(".*[Ww]indows.*");
+    }
+
+    public static class ProcessRunner implements Runnable {
+        final File directory;
+        final File log;
+        final String[] command;
+        final long timeoutMinutes;
+
+        public ProcessRunner(File directory, File log, String[] command, long timeoutMinutes) {
+            this.directory = directory;
+            this.log = log;
+            this.command = command;
+            this.timeoutMinutes = timeoutMinutes;
+        }
+
+        @Override
+        public void run() {
+            ProcessBuilder pb;
+            if (isThisWindows()) {
+                pb = new ProcessBuilder(ArrayUtils.addAll(new String[]{"cmd", "/C"}, command));
+            } else {
+                pb = new ProcessBuilder(ArrayUtils.addAll(command));
+            }
+            Map<String, String> env = pb.environment();
+            env.put("PATH", System.getenv("PATH"));
+            pb.directory(directory);
+            pb.redirectErrorStream(true);
+            pb.redirectOutput(ProcessBuilder.Redirect.to(log));
+            Process p = null;
+            try {
+                p = pb.start();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            try {
+                Objects.requireNonNull(p).waitFor(timeoutMinutes, TimeUnit.MINUTES);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/src/it/java/org/eclipse/microprofile/starter/utils/Commands.java
+++ b/src/it/java/org/eclipse/microprofile/starter/utils/Commands.java
@@ -44,7 +44,6 @@ import java.util.logging.Logger;
 
 import static org.eclipse.microprofile.starter.TestMatrixTest.API_URL;
 import static org.eclipse.microprofile.starter.TestMatrixTest.TMP;
-import static org.eclipse.microprofile.starter.utils.Logs.S;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -89,7 +88,7 @@ public class Commands {
         Map<String, String> env = pb.environment();
         env.put("PATH", System.getenv("PATH"));
         pb.directory(new File(TMP));
-        File unzipLog = new File(TMP + S + artifactId + "-unzip.log");
+        File unzipLog = new File(TMP + File.separator + artifactId + "-unzip.log");
         pb.redirectErrorStream(true);
         pb.redirectOutput(ProcessBuilder.Redirect.to(unzipLog));
         Process p = pb.start();
@@ -98,13 +97,18 @@ public class Commands {
         return unzipLog;
     }
 
+    /**
+     * Does not fail the TS. Makes best effort to clean up.
+     * @param artifactId by convention, this is a filename friendly name of the server
+     */
     public static void cleanWorkspace(String artifactId) {
-        String path = TMP + S + artifactId;
+        String path = TMP + File.separator + artifactId;
         try {
             FileUtils.deleteDirectory(new File(path));
         } catch (IOException e) {
             // Silence is golden
         }
+        // onExit covers corner cases on Windows if a fd lock is held
         (new File(path + ".zip")).deleteOnExit();
         (new File(path + "-unzip.log")).deleteOnExit();
         (new File(path + ".zip")).delete();

--- a/src/it/java/org/eclipse/microprofile/starter/utils/Logs.java
+++ b/src/it/java/org/eclipse/microprofile/starter/utils/Logs.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2017-2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.eclipse.microprofile.starter.utils;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Scanner;
+import java.util.logging.Logger;
+
+import static org.junit.Assert.assertFalse;
+
+/**
+ * @author Michal Karm Babacek <karm@redhat.com>
+ */
+public class Logs {
+    private static final Logger LOGGER = Logger.getLogger(Logs.class.getName());
+
+    public static final String S = File.separator;
+
+    public static void checkLog(String testClass, String testMethod, String logname, File log) throws FileNotFoundException {
+        String[] whiteList;
+        if (testMethod.contains(Whitelist.THORNTAIL_V2.name)) {
+            whiteList = Whitelist.THORNTAIL_V2.errs;
+        } else if (testMethod.contains(Whitelist.PAYARA_MICRO.name)) {
+            whiteList = Whitelist.PAYARA_MICRO.errs;
+        } else if (testMethod.contains(Whitelist.LIBERTY.name)) {
+            whiteList = Whitelist.LIBERTY.errs;
+        } else if (testMethod.contains(Whitelist.HELIDON.name)) {
+            whiteList = Whitelist.HELIDON.errs;
+        } else if (testMethod.contains(Whitelist.KUMULUZEE.name)) {
+            whiteList = Whitelist.KUMULUZEE.errs;
+        } else if (testMethod.contains(Whitelist.TOMEE.name)) {
+            whiteList = Whitelist.TOMEE.errs;
+        } else {
+            throw new IllegalArgumentException(
+                    "testMethod as matter of convention should always contain lower-case server name, e.g. thorntail");
+        }
+        try (Scanner sc = new Scanner(log)) {
+            while (sc.hasNextLine()) {
+                String line = sc.nextLine();
+                boolean error = line.matches("(?i:.*ERROR.*)");
+                boolean whiteListed = false;
+                if (error) {
+                    for (String w : whiteList) {
+                        if (line.contains(w)) {
+                            whiteListed = true;
+                            LOGGER.info(logname + " for " + testMethod + " contains whitelisted error: `" + line + "'");
+                            break;
+                        }
+                    }
+                }
+                assertFalse(logname + " should not contain `ERROR' lines that are not whitelisted. " +
+                                "See target" + S + "archived-logs" + S + testClass + S + testMethod + S + log.getName() + "",
+                        error && !whiteListed);
+            }
+        }
+    }
+
+    public static void archiveLog(String testClass, String testMethod, File log) throws IOException {
+        if (log == null || !log.exists()) {
+            LOGGER.severe("log must be a valid, existing file. Skipping operation.");
+            return;
+        }
+        if (StringUtils.isBlank(testClass)) {
+            throw new IllegalArgumentException("testClass must not be blank");
+        }
+        if (StringUtils.isBlank(testMethod)) {
+            throw new IllegalArgumentException("testMethod must not be blank");
+        }
+        Path destDir = new File(System.getProperties().get("basedir") + S + "target" + S + "archived-logs" + S + testClass + S + testMethod).toPath();
+        Files.createDirectories(destDir);
+        String filename = log.getName();
+        Files.copy(log.toPath(), Paths.get(destDir.toString(), filename));
+    }
+
+}

--- a/src/it/java/org/eclipse/microprofile/starter/utils/Logs.java
+++ b/src/it/java/org/eclipse/microprofile/starter/utils/Logs.java
@@ -38,8 +38,6 @@ import static org.junit.Assert.assertFalse;
 public class Logs {
     private static final Logger LOGGER = Logger.getLogger(Logs.class.getName());
 
-    public static final String S = File.separator;
-
     public static void checkLog(String testClass, String testMethod, String logname, File log) throws FileNotFoundException {
         String[] whiteList;
         if (testMethod.contains(Whitelist.THORNTAIL_V2.name)) {
@@ -73,7 +71,7 @@ public class Logs {
                     }
                 }
                 assertFalse(logname + " should not contain `ERROR' lines that are not whitelisted. " +
-                                "See target" + S + "archived-logs" + S + testClass + S + testMethod + S + log.getName() + "",
+                                "See target" + File.separator + "archived-logs" + File.separator + testClass + File.separator + testMethod + File.separator + log.getName() + "",
                         error && !whiteListed);
             }
         }
@@ -90,7 +88,7 @@ public class Logs {
         if (StringUtils.isBlank(testMethod)) {
             throw new IllegalArgumentException("testMethod must not be blank");
         }
-        Path destDir = new File(System.getProperties().get("basedir") + S + "target" + S + "archived-logs" + S + testClass + S + testMethod).toPath();
+        Path destDir = new File(System.getProperties().get("basedir") + File.separator + "target" + File.separator + "archived-logs" + File.separator + testClass + File.separator + testMethod).toPath();
         Files.createDirectories(destDir);
         String filename = log.getName();
         Files.copy(log.toPath(), Paths.get(destDir.toString(), filename));

--- a/src/it/java/org/eclipse/microprofile/starter/utils/MPSpec.java
+++ b/src/it/java/org/eclipse/microprofile/starter/utils/MPSpec.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2017-2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.eclipse.microprofile.starter.utils;
+
+/**
+ * @author Michal Karm Babacek <karm@redhat.com>
+ */
+public enum MPSpec {
+    DEFAULT(new String[][]{
+            new String[]{"data/hello", "Hello World"}
+    }),
+    CONFIG(new String[][]{
+            new String[]{"data/config/injected", "Config value as Injected by CDI Injected value"},
+            new String[]{"data/config/lookup", "Config value from ConfigProvider lookup value"}
+    }),
+    FAULT_TOLERANCE(new String[][]{
+            new String[]{"data/resilience", "Fallback answer due to timeout"}
+    }),
+    HEALTH_CHECKS(new String[][]{
+            new String[]{"health", "\"UP\""}
+    }),
+    METRICS(new String[][]{
+            new String[]{"data/metric/timed", "Request is used in statistics, check with the Metrics call."},
+            // Tomee has "metric_metric_controller", others have "MetricController". This will do.
+            new String[]{"metrics", "ontroller_timed_request_seconds_count"}
+    }),
+    JWT_AUTH(new String[][]{
+            // Helidon puts double quotes around the custom claim i.e. Custom value : "Jessie specific value",
+            // while other runtimes don't. Check relaxed just to the claim's value.
+            new String[]{"data/secured/test", "Jessie specific value"},
+    }),
+    OPEN_API(new String[][]{
+            // Tomee shows only /resilience:, all others show "/data/resilience".
+            new String[]{"openapi", "/resilience"}
+    }),
+    // TODO Install Jaeger?
+    //OPEN_TRACING(new String[][]{
+    //        new String[]{"URL", "expected string"},
+    //        new String[]{"URL 1", "expected string 1"}
+    //}),
+    REST_CLIENT(new String[][]{
+            new String[]{"data/client/test/parameterValue=xxx", "Processed parameter value 'parameterValue=xxx'"}
+    });
+
+    public final String[][] urlContent;
+
+    MPSpec(String[][] urlContent) {
+        this.urlContent = urlContent;
+    }
+}

--- a/src/it/java/org/eclipse/microprofile/starter/utils/MPSpec.java
+++ b/src/it/java/org/eclipse/microprofile/starter/utils/MPSpec.java
@@ -33,6 +33,8 @@ public enum MPSpec {
     FAULT_TOLERANCE(new String[][]{
             new String[]{"data/resilience", "Fallback answer due to timeout"}
     }),
+    // Note that there are runtimes ATTOW, such as Tomee, that do not do latest MP spec
+    //  and thus cannot do /health/ready endpoint. We stick to the largest common denominator here.
     HEALTH_CHECKS(new String[][]{
             new String[]{"health", "\"UP\""}
     }),

--- a/src/it/java/org/eclipse/microprofile/starter/utils/ReadmeParser.java
+++ b/src/it/java/org/eclipse/microprofile/starter/utils/ReadmeParser.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2017-2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.eclipse.microprofile.starter.utils;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.util.Scanner;
+
+/**
+ * @author Michal Karm Babacek <karm@redhat.com>
+ */
+public class ReadmeParser {
+    public static String[][] parseReadme(File readme, boolean isServiceA) {
+        String[] buildCommand = null;
+        String[] runCommand = null;
+        String[] webAddress = null;
+        try (Scanner sc = new Scanner(readme)) {
+            while (sc.hasNextLine()) {
+                if (buildCommand != null && runCommand != null && webAddress != null) {
+                    break;
+                }
+                String line = sc.nextLine();
+                if (buildCommand == null && line.startsWith("    mvn")) {
+                    buildCommand = splitBySpace(line);
+                }
+                if (runCommand == null && line.startsWith("    java")) {
+                    runCommand = splitBySpace(line);
+                }
+                if (webAddress == null && isServiceA && line.startsWith("    http://")) {
+                    webAddress = splitBySpace(line);
+                }
+            }
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        }
+        if (isServiceA) {
+            return new String[][]{buildCommand, runCommand, webAddress};
+        }
+        return new String[][]{buildCommand, runCommand};
+    }
+
+    private static String[] splitBySpace(String line) {
+        return StringUtils.trim(line).split(" ");
+    }
+}

--- a/src/it/java/org/eclipse/microprofile/starter/utils/ReadmeParser.java
+++ b/src/it/java/org/eclipse/microprofile/starter/utils/ReadmeParser.java
@@ -19,8 +19,6 @@
  */
 package org.eclipse.microprofile.starter.utils;
 
-import org.apache.commons.lang3.StringUtils;
-
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.Scanner;
@@ -29,7 +27,7 @@ import java.util.Scanner;
  * @author Michal Karm Babacek <karm@redhat.com>
  */
 public class ReadmeParser {
-    public static String[][] parseReadme(File readme, boolean isServiceA) {
+    public static String[][] parseReadme(File readme, boolean isServiceA) throws FileNotFoundException {
         String[] buildCommand = null;
         String[] runCommand = null;
         String[] webAddress = null;
@@ -40,25 +38,19 @@ public class ReadmeParser {
                 }
                 String line = sc.nextLine();
                 if (buildCommand == null && line.startsWith("    mvn")) {
-                    buildCommand = splitBySpace(line);
+                    buildCommand = line.trim().split(" ");
                 }
                 if (runCommand == null && line.startsWith("    java")) {
-                    runCommand = splitBySpace(line);
+                    runCommand = line.trim().split(" ");
                 }
                 if (webAddress == null && isServiceA && line.startsWith("    http://")) {
-                    webAddress = splitBySpace(line);
+                    webAddress = line.trim().split(" ");
                 }
             }
-        } catch (FileNotFoundException e) {
-            e.printStackTrace();
         }
         if (isServiceA) {
             return new String[][]{buildCommand, runCommand, webAddress};
         }
         return new String[][]{buildCommand, runCommand};
-    }
-
-    private static String[] splitBySpace(String line) {
-        return StringUtils.trim(line).split(" ");
     }
 }

--- a/src/it/java/org/eclipse/microprofile/starter/utils/SpecSelection.java
+++ b/src/it/java/org/eclipse/microprofile/starter/utils/SpecSelection.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2017-2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.eclipse.microprofile.starter.utils;
+
+/**
+ * @author Michal Karm Babacek <karm@redhat.com>
+ */
+public enum SpecSelection {
+    EMPTY("", false),
+    ALL("&selectAllSpecs=true", true),
+    ALL_BUT_JWT_REST(
+            "&selectedSpecs=CONFIG" +
+                    "&selectedSpecs=FAULT_TOLERANCE" +
+                    "&selectedSpecs=HEALTH_CHECKS" +
+                    "&selectedSpecs=METRICS" +
+                    "&selectedSpecs=OPEN_TRACING" +
+                    "&selectedSpecs=OPEN_API", false),
+    JWT_REST("&selectedSpecs=JWT_AUTH&selectedSpecs=REST_CLIENT", true);
+
+    public final String queryParam;
+    public final boolean hasServiceB;
+
+    SpecSelection(String queryParam, boolean hasServiceB) {
+        this.queryParam = queryParam;
+        this.hasServiceB = hasServiceB;
+    }
+}

--- a/src/it/java/org/eclipse/microprofile/starter/utils/WebpageTester.java
+++ b/src/it/java/org/eclipse/microprofile/starter/utils/WebpageTester.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2017-2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.eclipse.microprofile.starter.utils;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
+import java.util.Scanner;
+import java.util.logging.Logger;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Michal Karm Babacek <karm@redhat.com>
+ */
+public class WebpageTester {
+    private static final Logger LOGGER = Logger.getLogger(WebpageTester.class.getName());
+
+    /**
+     * Patiently try to wait for a web page and examine it
+     *
+     * @param url             address
+     * @param timeoutS        in seconds
+     * @param stringToLookFor string must be present on the page
+     */
+    public static void testWeb(String url, long timeoutS, String stringToLookFor) throws InterruptedException, IOException {
+        if (StringUtils.isBlank(url)) {
+            throw new IllegalArgumentException("url must not be empty");
+        }
+        if (timeoutS < 0) {
+            throw new IllegalArgumentException("timeoutS must be positive");
+        }
+        if (stringToLookFor == null ||
+                StringUtils.isBlank(stringToLookFor)) {
+            throw new IllegalArgumentException("stringToLookFor must contain a non-empty string");
+        }
+        String webPage = "";
+        long now = System.currentTimeMillis();
+        long startTime = now;
+        boolean found = false;
+        while (now - startTime < 1000 * timeoutS) {
+            URLConnection c = new URL(url).openConnection();
+            // Server returned HTTP response code: 406 for URL: http://localhost:8080/metrics
+            c.setRequestProperty("Accept", "*/*");
+            c.setConnectTimeout(500);
+            try (Scanner scanner = new Scanner(c.getInputStream(), StandardCharsets.UTF_8.toString())) {
+                scanner.useDelimiter("\\A");
+                webPage = scanner.hasNext() ? scanner.next() : "";
+            } catch (Exception e) {
+                LOGGER.fine("Waiting `" + stringToLookFor + "' to appear on " + url);
+            }
+            if (webPage.contains(stringToLookFor)) {
+                found = true;
+                break;
+            }
+            Thread.sleep(500);
+            now = System.currentTimeMillis();
+        }
+        // Test landing page
+        assertTrue(webPage + " must contain string: `" + stringToLookFor + "'", found);
+    }
+}

--- a/src/it/java/org/eclipse/microprofile/starter/utils/WebpageTester.java
+++ b/src/it/java/org/eclipse/microprofile/starter/utils/WebpageTester.java
@@ -50,14 +50,15 @@ public class WebpageTester {
         if (timeoutS < 0) {
             throw new IllegalArgumentException("timeoutS must be positive");
         }
-        if (stringToLookFor == null ||
-                StringUtils.isBlank(stringToLookFor)) {
+        if (StringUtils.isBlank(stringToLookFor)) {
             throw new IllegalArgumentException("stringToLookFor must contain a non-empty string");
         }
         String webPage = "";
         long now = System.currentTimeMillis();
         long startTime = now;
         boolean found = false;
+        // Some runtimes give you HTTP 404 or even HTTP 200 with empty response
+        // the very moment the web app is being deployed. We patiently wait for the correct result here.
         while (now - startTime < 1000 * timeoutS) {
             URLConnection c = new URL(url).openConnection();
             // Server returned HTTP response code: 406 for URL: http://localhost:8080/metrics

--- a/src/it/java/org/eclipse/microprofile/starter/utils/Whitelist.java
+++ b/src/it/java/org/eclipse/microprofile/starter/utils/Whitelist.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2017-2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.eclipse.microprofile.starter.utils;
+
+/**
+ * Whitelists errors in log files.
+ *
+ * Ideally should be empty :)
+ *
+ * @author Michal Karm Babacek <karm@redhat.com>
+ */
+public enum Whitelist {
+    THORNTAIL_V2("thorntail", new String[]{}),
+    PAYARA_MICRO("payara", new String[]{}),
+    LIBERTY("liberty", new String[]{
+            "OpenTracing cannot track JAX-RS requests because an OpentracingTracerFactory class was not provided."
+    }),
+    HELIDON("helidon", new String[]{}),
+    KUMULUZEE("kumuluzee", new String[]{"Copying error_prone_annotations"}),
+    TOMEE("tomee", new String[]{});
+
+    public final String name;
+    public final String[] errs;
+
+    Whitelist(String name, String[] errs) {
+        this.name = name;
+        this.errs = errs;
+    }
+}

--- a/src/test/java/org/eclipse/microprofile/starter/readmeparser/ReadmeParserTest.java
+++ b/src/test/java/org/eclipse/microprofile/starter/readmeparser/ReadmeParserTest.java
@@ -1,0 +1,84 @@
+package org.eclipse.microprofile.starter.readmeparser;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.eclipse.microprofile.starter.utils.ReadmeParser.parseReadme;
+import static org.junit.Assert.assertArrayEquals;
+
+public class ReadmeParserTest {
+
+    @Test
+    public void demoLoggingTest() {
+
+        Map<String, String[][]> conf = new HashMap<>();
+
+        conf.put("li-service-a-readme.md",
+                new String[][]{
+                        new String[]{"mvn", "clean", "package"},
+                        new String[]{"java", "-jar", "target/liberty.jar"},
+                        new String[]{"http://localhost:8181/index.html"}
+                });
+        conf.put("li-service-b-readme.md",
+                new String[][]{
+                        new String[]{"mvn", "clean", "package"},
+                        new String[]{"java", "-jar", "target/liberty.jar"}
+                });
+        conf.put("py-service-a-readme.md",
+                new String[][]{
+                        new String[]{"mvn", "clean", "package"},
+                        new String[]{"java", "-jar", "target/payara-microbundle.jar"},
+                        new String[]{"http://localhost:8080/index.html"}
+                });
+        conf.put("py-service-b-readme.md",
+                new String[][]{
+                        new String[]{"mvn", "clean", "package"},
+                        new String[]{"java", "-jar", "target/payara-microbundle.jar", "--port", "8180"}
+                });
+        conf.put("q-service-a-readme.md",
+                new String[][]{
+                        new String[]{"mvn", "clean", "compile", "quarkus:build"},
+                        new String[]{"java", "-jar", "target/quarkus-runner.jar"},
+                        new String[]{"http://localhost:8080/index.html"}
+                });
+        conf.put("q-service-b-readme.md",
+                new String[][]{
+                        new String[]{"mvn", "clean", "compile", "quarkus:build"},
+                        new String[]{"java", "-Dquarkus.http.port=8180", "-jar", "target/quarkus-runner.jar"}
+                });
+        conf.put("th-service-a-readme.md",
+                new String[][]{
+                        new String[]{"mvn", "clean", "package"},
+                        new String[]{"java", "-jar", "target/thorntail-thorntail.jar"},
+                        new String[]{"http://localhost:8080/index.html"}
+                });
+        conf.put("th-service-b-readme.md",
+                new String[][]{
+                        new String[]{"mvn", "clean", "package"},
+                        new String[]{"java", "-jar", "target/thorntail-thorntail.jar", "-Dswarm.port.offset=100"}
+                });
+
+        conf.forEach((f, c) -> {
+            File readme = new File(
+                    getClass().getClassLoader().getResource("readme_examples/" + f).getFile()
+            );
+
+            boolean isServiceA = f.contains("-a-");
+            String[][] buildCmdRunCmdWebAddr = parseReadme(readme, isServiceA);
+
+            assertArrayEquals("Build command parsing failed. Expected: " +
+                    Arrays.toString(c[0]) + ", Was:" + Arrays.toString(buildCmdRunCmdWebAddr[0]), c[0], buildCmdRunCmdWebAddr[0]);
+            assertArrayEquals("Run command failed. Expected: " +
+                    Arrays.toString(c[1]) + ", Was:" + Arrays.toString(buildCmdRunCmdWebAddr[1]), c[1], buildCmdRunCmdWebAddr[1]);
+            if (isServiceA) {
+                assertArrayEquals("Web address parsing failed Expected: " +
+                        Arrays.toString(c[2]) + ", Was:" + Arrays.toString(buildCmdRunCmdWebAddr[2]), c[2], buildCmdRunCmdWebAddr[2]);
+            }
+
+        });
+    }
+}

--- a/src/test/java/org/eclipse/microprofile/starter/readmeparser/ReadmeParserTest.java
+++ b/src/test/java/org/eclipse/microprofile/starter/readmeparser/ReadmeParserTest.java
@@ -1,8 +1,10 @@
 package org.eclipse.microprofile.starter.readmeparser;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -68,7 +70,12 @@ public class ReadmeParserTest {
             );
 
             boolean isServiceA = f.contains("-a-");
-            String[][] buildCmdRunCmdWebAddr = parseReadme(readme, isServiceA);
+            String[][] buildCmdRunCmdWebAddr = new String[0][];
+            try {
+                buildCmdRunCmdWebAddr = parseReadme(readme, isServiceA);
+            } catch (FileNotFoundException e) {
+                Assert.fail(e.getMessage());
+            }
 
             assertArrayEquals("Build command parsing failed. Expected: " +
                     Arrays.toString(c[0]) + ", Was:" + Arrays.toString(buildCmdRunCmdWebAddr[0]), c[0], buildCmdRunCmdWebAddr[0]);

--- a/src/test/resources/arquillian.xml
+++ b/src/test/resources/arquillian.xml
@@ -1,0 +1,11 @@
+<arquillian xmlns="http://jboss.org/schema/arquillian"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="
+        http://jboss.org/schema/arquillian
+        http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+    <container qualifier="wildfly-swarm" default="true">
+        <configuration>
+            <property name="javaVmArguments">-Dthorntail.http.port=9090</property>
+        </configuration>
+    </container>
+</arquillian>

--- a/src/test/resources/readme_examples/li-service-a-readme.md
+++ b/src/test/resources/readme_examples/li-service-a-readme.md
@@ -1,0 +1,104 @@
+# MicroProfile generated Application
+
+## Introduction
+
+MicroProfile Starter has generated this MicroProfile application for you.
+
+The generation of the executable jar file can be performed by issuing the following command
+
+    mvn clean package
+
+This will create an executable jar file **liberty.jar** within the _target_ maven folder. This can be started by executing the following command
+
+    java -jar target/liberty.jar
+
+
+### Liberty Dev Mode
+
+During development, you can use Liberty's development mode (dev mode) to code while observing and testing your changes on the fly.
+With the dev mode, you can code along and watch the change reflected in the running server right away; 
+unit and integration tests are run on pressing Enter in the command terminal; you can attach a debugger to the running server at any time to step through your code.
+
+    mvn liberty:dev
+
+
+
+To launch the test page, open your browser at the following URL
+
+    http://localhost:8181/index.html
+
+## Specification examples
+
+By default, there is always the creation of a JAX-RS application class to define the path on which the JAX-RS endpoints are available.
+
+Also, a simple Hello world endpoint is created, have a look at the class **HelloController**.
+
+More information on MicroProfile can be found [here](https://microprofile.io/)
+
+
+### Config
+
+Configuration of your application parameters. Specification [here](https://microprofile.io/project/eclipse/microprofile-config)
+
+The example class **ConfigTestController** shows you how to inject a configuration parameter and how you can retrieve it programmatically.
+
+
+
+### Fault tolerance
+
+Add resilient features to your applications like TimeOut, RetryPolicy, Fallback, bulkhead and circuit breaker. Specification [here](https://microprofile.io/project/eclipse/microprofile-fault-tolerance)
+
+The example class **ResilienceController** has an example of a FallBack mechanism where an fallback result is returned when the execution takes too long.
+
+
+
+### Health
+
+The health status can be used to determine if the 'computing node' needs to be discarded/restarted or not. Specification [here](https://microprofile.io/project/eclipse/microprofile-health)
+
+The class **ServiceHealthCheck** contains an example of a custom check which can be integrated to health status checks of the instance.  The index page contains a link to the status data.
+
+
+
+### Metrics
+
+The Metrics exports _Telemetric_ data in a uniform way of system and custom resources. Specification [here](https://microprofile.io/project/eclipse/microprofile-metrics)
+
+The example class **MetricController** contains an example how you can measure the execution time of a request.  The index page also contains a link to the metric page (with all metric info)
+
+
+
+### JWT Auth
+
+Using the OpenId Connect JWT token to pass authentication and authorization information to the JAX-RS endpoint. Specification [here](https://microprofile.io/project/eclipse/microprofile-rest-client)
+
+Have a look at the **TestSecureController** class which calls the protected endpoint on the secondary application.
+The **ProtectedController** (secondary application) contains the protected endpoint since it contains the _@RolesAllowed_ annotation on the JAX-RS endpoint method.
+
+The _TestSecureController_ code creates a JWT based on the private key found within the resource directory.
+However, any method to send a REST request with an appropriate header will work of course. Please feel free to change this code to your needs.
+
+
+
+### Open API
+
+Exposes the information about your endpoints in the format of the OpenAPI v3 specification. Specification [here](https://microprofile.io/project/eclipse/microprofile-open-api)
+
+The index page contains a link to the OpenAPI information of your endpoints.
+
+
+
+
+### Open Tracing
+
+Allow the participation in distributed tracing of your requests through various micro services. Specification [here](https://microprofile.io/project/eclipse/microprofile-opentracing)
+
+Example needs to be created.
+
+
+
+### Rest Client
+
+A type safe invocation of HTTP rest endpoints. Specification [here](https://microprofile.io/project/eclipse/microprofile-rest-client)
+
+The example calls one endpoint from another JAX-RS resource where generated Rest Client is injected as CDI bean.

--- a/src/test/resources/readme_examples/li-service-b-readme.md
+++ b/src/test/resources/readme_examples/li-service-b-readme.md
@@ -1,0 +1,43 @@
+# MicroProfile generated Application
+
+## Introduction
+
+MicroProfile Starter has generated this MicroProfile application for you containing some endpoints which are called from the main application (see the `service-a` directory)
+
+The generation of the executable jar file can be performed by issuing the following command
+
+    mvn clean package
+
+This will create an executable jar file **liberty.jar** within the _target_ maven folder. This can be started by executing the following command
+
+    java -jar target/liberty.jar 
+
+
+
+### Liberty's Dev Mode
+
+During development, you can use Liberty's development mode (dev mode) to code while observing and testing your changes on the fly.
+With the dev mode, you can code along and watch the change reflected in the running server right away; 
+unit and integration tests are run on pressing Enter in the command terminal; you can attach a debugger to the running server at any time to step through your code.
+
+    mvn liberty:dev
+
+## Specification examples
+
+
+### JWT Auth
+
+Have a look at the **TestSecureController** class (main application) which calls the protected endpoint on the secondary application.
+The **ProtectedController** contains the protected endpoint since it contains the _@RolesAllowed_ annotation on the JAX-RS endpoint method.
+
+The _TestSecureController_ code creates a JWT based on the private key found within the resource directory.
+However, any method to send a REST request with an appropriate header will work of course. Please feel free to change this code to your needs.
+
+
+
+
+### Rest Client
+
+A type safe invocation of HTTP rest endpoints. Specification [here](https://microprofile.io/project/eclipse/microprofile-rest-client)
+
+The example calls one endpoint from another JAX-RS resource where generated Rest Client is injected as CDI bean.

--- a/src/test/resources/readme_examples/py-service-a-readme.md
+++ b/src/test/resources/readme_examples/py-service-a-readme.md
@@ -1,0 +1,96 @@
+# MicroProfile generated Application
+
+## Introduction
+
+MicroProfile Starter has generated this MicroProfile application for you.
+
+The generation of the executable jar file can be performed by issuing the following command
+
+    mvn clean package
+
+This will create an executable jar file **payara-microbundle.jar** within the _target_ maven folder. This can be started by executing the following command
+
+    java -jar target/payara-microbundle.jar
+
+
+
+
+To launch the test page, open your browser at the following URL
+
+    http://localhost:8080/index.html
+
+## Specification examples
+
+By default, there is always the creation of a JAX-RS application class to define the path on which the JAX-RS endpoints are available.
+
+Also, a simple Hello world endpoint is created, have a look at the class **HelloController**.
+
+More information on MicroProfile can be found [here](https://microprofile.io/)
+
+
+### Config
+
+Configuration of your application parameters. Specification [here](https://microprofile.io/project/eclipse/microprofile-config)
+
+The example class **ConfigTestController** shows you how to inject a configuration parameter and how you can retrieve it programmatically.
+
+
+
+### Fault tolerance
+
+Add resilient features to your applications like TimeOut, RetryPolicy, Fallback, bulkhead and circuit breaker. Specification [here](https://microprofile.io/project/eclipse/microprofile-fault-tolerance)
+
+The example class **ResilienceController** has an example of a FallBack mechanism where an fallback result is returned when the execution takes too long.
+
+
+
+### Health
+
+The health status can be used to determine if the 'computing node' needs to be discarded/restarted or not. Specification [here](https://microprofile.io/project/eclipse/microprofile-health)
+
+The class **ServiceHealthCheck** contains an example of a custom check which can be integrated to health status checks of the instance.  The index page contains a link to the status data.
+
+
+
+### Metrics
+
+The Metrics exports _Telemetric_ data in a uniform way of system and custom resources. Specification [here](https://microprofile.io/project/eclipse/microprofile-metrics)
+
+The example class **MetricController** contains an example how you can measure the execution time of a request.  The index page also contains a link to the metric page (with all metric info)
+
+
+
+### JWT Auth
+
+Using the OpenId Connect JWT token to pass authentication and authorization information to the JAX-RS endpoint. Specification [here](https://microprofile.io/project/eclipse/microprofile-rest-client)
+
+Have a look at the **TestSecureController** class which calls the protected endpoint on the secondary application.
+The **ProtectedController** (secondary application) contains the protected endpoint since it contains the _@RolesAllowed_ annotation on the JAX-RS endpoint method.
+
+The _TestSecureController_ code creates a JWT based on the private key found within the resource directory.
+However, any method to send a REST request with an appropriate header will work of course. Please feel free to change this code to your needs.
+
+
+
+### Open API
+
+Exposes the information about your endpoints in the format of the OpenAPI v3 specification. Specification [here](https://microprofile.io/project/eclipse/microprofile-open-api)
+
+The index page contains a link to the OpenAPI information of your endpoints.
+
+
+
+
+### Open Tracing
+
+Allow the participation in distributed tracing of your requests through various micro services. Specification [here](https://microprofile.io/project/eclipse/microprofile-opentracing)
+
+Example needs to be created.
+
+
+
+### Rest Client
+
+A type safe invocation of HTTP rest endpoints. Specification [here](https://microprofile.io/project/eclipse/microprofile-rest-client)
+
+The example calls one endpoint from another JAX-RS resource where generated Rest Client is injected as CDI bean.

--- a/src/test/resources/readme_examples/py-service-b-readme.md
+++ b/src/test/resources/readme_examples/py-service-b-readme.md
@@ -1,0 +1,35 @@
+# MicroProfile generated Application
+
+## Introduction
+
+MicroProfile Starter has generated this MicroProfile application for you containing some endpoints which are called from the main application (see the `service-a` directory)
+
+The generation of the executable jar file can be performed by issuing the following command
+
+    mvn clean package
+
+This will create an executable jar file **payara-microbundle.jar** within the _target_ maven folder. This can be started by executing the following command
+
+    java -jar target/payara-microbundle.jar --port 8180
+
+
+
+## Specification examples
+
+
+### JWT Auth
+
+Have a look at the **TestSecureController** class (main application) which calls the protected endpoint on the secondary application.
+The **ProtectedController** contains the protected endpoint since it contains the _@RolesAllowed_ annotation on the JAX-RS endpoint method.
+
+The _TestSecureController_ code creates a JWT based on the private key found within the resource directory.
+However, any method to send a REST request with an appropriate header will work of course. Please feel free to change this code to your needs.
+
+
+
+
+### Rest Client
+
+A type safe invocation of HTTP rest endpoints. Specification [here](https://microprofile.io/project/eclipse/microprofile-rest-client)
+
+The example calls one endpoint from another JAX-RS resource where generated Rest Client is injected as CDI bean.

--- a/src/test/resources/readme_examples/q-service-a-readme.md
+++ b/src/test/resources/readme_examples/q-service-a-readme.md
@@ -1,0 +1,115 @@
+# MicroProfile generated Application
+
+## Introduction
+
+MicroProfile Starter has generated this MicroProfile application for you.
+
+The generation of the executable jar file can be performed by issuing the following command
+
+    mvn clean compile quarkus:build
+
+This will create a jar file **quarkus-runner.jar** within the _target_ maven folder. This can be started by executing the following command
+
+    java -jar target/quarkus-runner.jar
+
+You can also start the project in development mode where it automatically updates code on the fly as you save your files:
+
+    mvn clean compile quarkus:dev
+
+Last but not least, you can build the whole application into a one statically linked executable that does not require JVM:
+
+    mvn clean compile quarkus:native-image -Pnative
+
+Native executable build might take a minute. Then you can execute it on a compatible architecture without JVM:
+
+    ./target/quarkus-runner
+
+To launch the test page, open your browser at the following URL
+
+    http://localhost:8080/index.html
+
+## Note on Native image
+
+ * You need GraalVM installed from the GraalVM web site. Using the community edition is enough. Version 19.1.1+ is required.
+ * The GRAALVM_HOME environment variable configured appropriately
+ * The native-image tool must be installed; this can be done by running ```gu install native-image``` from your GraalVM directory
+ * To read more about Quarkus and Native image, see https://quarkus.io/guides/building-native-image-guide
+
+## Specification examples
+
+By default, there is always the creation of a JAX-RS application class to define the path on which the JAX-RS endpoints are available.
+
+Also, a simple Hello world endpoint is created, have a look at the class **HelloController**.
+
+More information on MicroProfile can be found [here](https://microprofile.io/)
+
+
+### Config
+
+Configuration of your application parameters. Specification [here](https://microprofile.io/project/eclipse/microprofile-config)
+
+The example class **ConfigTestController** shows you how to inject a configuration parameter and how you can retrieve it programmatically.
+
+
+
+### Fault tolerance
+
+Add resilient features to your applications like TimeOut, RetryPolicy, Fallback, bulkhead and circuit breaker. Specification [here](https://microprofile.io/project/eclipse/microprofile-fault-tolerance)
+
+The example class **ResilienceController** has an example of a FallBack mechanism where an fallback result is returned when the execution takes too long.
+
+
+
+### Health
+
+The health status can be used to determine if the 'computing node' needs to be discarded/restarted or not. Specification [here](https://microprofile.io/project/eclipse/microprofile-health)
+
+The class **ServiceHealthCheck** contains an example of a custom check which can be integrated to health status checks of the instance.  The index page contains a link to the status data.
+
+
+
+### Metrics
+
+The Metrics exports _Telemetric_ data in a uniform way of system and custom resources. Specification [here](https://microprofile.io/project/eclipse/microprofile-metrics)
+
+The example class **MetricController** contains an example how you can measure the execution time of a request.  The index page also contains a link to the metric page (with all metric info)
+
+
+
+### JWT Auth
+
+Using the OpenId Connect JWT token to pass authentication and authorization information to the JAX-RS endpoint. Specification [here](https://microprofile.io/project/eclipse/microprofile-rest-client)
+
+Have a look at the **TestSecureController** class which calls the protected endpoint on the secondary application.
+The **ProtectedController** (secondary application) contains the protected endpoint since it contains the _@RolesAllowed_ annotation on the JAX-RS endpoint method.
+
+The _TestSecureController_ code creates a JWT based on the private key found within the resource directory.
+However, any method to send a REST request with an appropriate header will work of course. Please feel free to change this code to your needs.
+
+
+
+### Open API
+
+Exposes the information about your endpoints in the format of the OpenAPI v3 specification. Specification [here](https://microprofile.io/project/eclipse/microprofile-open-api)
+
+The index page contains a link to the OpenAPI information of your endpoints.
+
+
+
+
+### Open Tracing
+
+Allow the participation in distributed tracing of your requests through various micro services. Specification [here](https://microprofile.io/project/eclipse/microprofile-opentracing)
+
+To show this capability download [Jaeger](https://www.jaegertracing.io/download/#binaries) and run ```./jaeger-all-in-one```.
+Open [http://localhost:16686/](http://localhost:16686/) to see the traces. Mind that you have to access your demo app endpoint for any traces to show on Jaeger UI.
+
+
+
+
+### Rest Client
+
+A type safe invocation of HTTP rest endpoints. Specification [here](https://microprofile.io/project/eclipse/microprofile-rest-client)
+
+The example calls one endpoint from another JAX-RS resource where generated Rest Client is injected as CDI bean.
+

--- a/src/test/resources/readme_examples/q-service-b-readme.md
+++ b/src/test/resources/readme_examples/q-service-b-readme.md
@@ -1,0 +1,52 @@
+# MicroProfile generated Application
+
+## Introduction
+
+MicroProfile Starter has generated this MicroProfile application for you containing some endpoints which are called from the main application (see the `service-a` directory)
+
+The generation of the executable jar file can be performed by issuing the following command
+
+    mvn clean compile quarkus:build
+
+This will create a jar file **quarkus-runner.jar** within the _target_ maven folder. This can be started by executing the following command
+
+    java -Dquarkus.http.port=8180 -jar target/quarkus-runner.jar
+
+You can also start the project in development mode where it automatically updates code on the fly as you save your files:
+
+    mvn -Dquarkus.http.port=8180 clean compile quarkus:dev
+
+Last but not least, you can build the whole application into a one statically linked executable that does not require JVM:
+
+    mvn clean compile quarkus:native-image -Pnative
+
+Native executable build might take a minute. Then you can execute it on a compatible architecture without JVM:
+
+    ./target/quarkus-runner -Dquarkus.http.port=8180
+
+## Note on Native image
+
+ * You need GraalVM installed from the GraalVM web site. Using the community edition is enough. Version 19.1.1+ is required.
+ * The GRAALVM_HOME environment variable configured appropriately
+ * The native-image tool must be installed; this can be done by running ```gu install native-image``` from your GraalVM directory
+
+## Specification examples
+
+
+### JWT Auth
+
+Have a look at the **TestSecureController** class (main application) which calls the protected endpoint on the secondary application.
+The **ProtectedController** contains the protected endpoint since it contains the _@RolesAllowed_ annotation on the JAX-RS endpoint method.
+
+The _TestSecureController_ code creates a JWT based on the private key found within the resource directory.
+However, any method to send a REST request with an appropriate header will work of course. Please feel free to change this code to your needs.
+
+
+
+
+### Rest Client
+
+A type safe invocation of HTTP rest endpoints. Specification [here](https://microprofile.io/project/eclipse/microprofile-rest-client)
+
+The example calls one endpoint from another JAX-RS resource where generated Rest Client is injected as CDI bean.
+

--- a/src/test/resources/readme_examples/th-service-a-readme.md
+++ b/src/test/resources/readme_examples/th-service-a-readme.md
@@ -1,0 +1,96 @@
+# MicroProfile generated Application
+
+## Introduction
+
+MicroProfile Starter has generated this MicroProfile application for you.
+
+The generation of the executable jar file can be performed by issuing the following command
+
+    mvn clean package
+
+This will create an executable jar file **thorntail-thorntail.jar** within the _target_ maven folder. This can be started by executing the following command
+
+    java -jar target/thorntail-thorntail.jar
+
+
+
+
+To launch the test page, open your browser at the following URL
+
+    http://localhost:8080/index.html
+
+## Specification examples
+
+By default, there is always the creation of a JAX-RS application class to define the path on which the JAX-RS endpoints are available.
+
+Also, a simple Hello world endpoint is created, have a look at the class **HelloController**.
+
+More information on MicroProfile can be found [here](https://microprofile.io/)
+
+
+### Config
+
+Configuration of your application parameters. Specification [here](https://microprofile.io/project/eclipse/microprofile-config)
+
+The example class **ConfigTestController** shows you how to inject a configuration parameter and how you can retrieve it programmatically.
+
+
+
+### Fault tolerance
+
+Add resilient features to your applications like TimeOut, RetryPolicy, Fallback, bulkhead and circuit breaker. Specification [here](https://microprofile.io/project/eclipse/microprofile-fault-tolerance)
+
+The example class **ResilienceController** has an example of a FallBack mechanism where an fallback result is returned when the execution takes too long.
+
+
+
+### Health
+
+The health status can be used to determine if the 'computing node' needs to be discarded/restarted or not. Specification [here](https://microprofile.io/project/eclipse/microprofile-health)
+
+The class **ServiceHealthCheck** contains an example of a custom check which can be integrated to health status checks of the instance.  The index page contains a link to the status data.
+
+
+
+### Metrics
+
+The Metrics exports _Telemetric_ data in a uniform way of system and custom resources. Specification [here](https://microprofile.io/project/eclipse/microprofile-metrics)
+
+The example class **MetricController** contains an example how you can measure the execution time of a request.  The index page also contains a link to the metric page (with all metric info)
+
+
+
+### JWT Auth
+
+Using the OpenId Connect JWT token to pass authentication and authorization information to the JAX-RS endpoint. Specification [here](https://microprofile.io/project/eclipse/microprofile-rest-client)
+
+Have a look at the **TestSecureController** class which calls the protected endpoint on the secondary application.
+The **ProtectedController** (secondary application) contains the protected endpoint since it contains the _@RolesAllowed_ annotation on the JAX-RS endpoint method.
+
+The _TestSecureController_ code creates a JWT based on the private key found within the resource directory.
+However, any method to send a REST request with an appropriate header will work of course. Please feel free to change this code to your needs.
+
+
+
+### Open API
+
+Exposes the information about your endpoints in the format of the OpenAPI v3 specification. Specification [here](https://microprofile.io/project/eclipse/microprofile-open-api)
+
+The index page contains a link to the OpenAPI information of your endpoints.
+
+
+
+
+### Open Tracing
+
+Allow the participation in distributed tracing of your requests through various micro services. Specification [here](https://microprofile.io/project/eclipse/microprofile-opentracing)
+
+Example needs to be created.
+
+
+
+### Rest Client
+
+A type safe invocation of HTTP rest endpoints. Specification [here](https://microprofile.io/project/eclipse/microprofile-rest-client)
+
+The example calls one endpoint from another JAX-RS resource where generated Rest Client is injected as CDI bean.

--- a/src/test/resources/readme_examples/th-service-b-readme.md
+++ b/src/test/resources/readme_examples/th-service-b-readme.md
@@ -1,0 +1,35 @@
+# MicroProfile generated Application
+
+## Introduction
+
+MicroProfile Starter has generated this MicroProfile application for you containing some endpoints which are called from the main application (see the `service-a` directory)
+
+The generation of the executable jar file can be performed by issuing the following command
+
+    mvn clean package
+
+This will create an executable jar file **thorntail-thorntail.jar** within the _target_ maven folder. This can be started by executing the following command
+
+    java -jar target/thorntail-thorntail.jar -Dswarm.port.offset=100
+
+
+
+## Specification examples
+
+
+### JWT Auth
+
+Have a look at the **TestSecureController** class (main application) which calls the protected endpoint on the secondary application.
+The **ProtectedController** contains the protected endpoint since it contains the _@RolesAllowed_ annotation on the JAX-RS endpoint method.
+
+The _TestSecureController_ code creates a JWT based on the private key found within the resource directory.
+However, any method to send a REST request with an appropriate header will work of course. Please feel free to change this code to your needs.
+
+
+
+
+### Rest Client
+
+A type safe invocation of HTTP rest endpoints. Specification [here](https://microprofile.io/project/eclipse/microprofile-rest-client)
+
+The example calls one endpoint from another JAX-RS resource where generated Rest Client is injected as CDI bean.

--- a/version.txt.bat
+++ b/version.txt.bat
@@ -1,0 +1,2 @@
+git describe --tags> .\version.txt
+


### PR DESCRIPTION
See [src/it/README.md](https://github.com/Karm/microprofile-starter/blob/tests/src/it/README.md) for details on what the TS does and how.

Some components and dependencies changes to be looked at:

* Thorntail upgraded from 2.2.1 to 2.5.0. I needed that for better Arquillian support. I figure we already established with CQs that this runtime dependency is not a problem.
 * Adds a dependency on RestEasy 4.3.0.Final
 * Adds dependency on maven-failsafe-plugin
 * Lifts Java requirement from 1.8 to 11

# It works for all runtimes on Linux
It correctly hit the Helidon package problem, so it made me rebase. It also hit an error message from Liberty which I whitelisted. More on whitelisting is in [src/it/README.md](https://github.com/Karm/microprofile-starter/blob/tests/src/it/README.md).

```
...
INFO: Testing server: THORNTAIL_V2, config: EMPTY
INFO: Testing server: THORNTAIL_V2, config: ALL
INFO: Testing server: THORNTAIL_V2, config: ALL_BUT_JWT_REST
INFO: Testing server: THORNTAIL_V2, config: JWT_REST
INFO: Testing server: PAYARA_MICRO, config: EMPTY
INFO: Testing server: PAYARA_MICRO, config: ALL
INFO: Testing server: PAYARA_MICRO, config: ALL_BUT_JWT_REST
INFO: Testing server: PAYARA_MICRO, config: JWT_REST
INFO: Testing server: LIBERTY, config: EMPTY
INFO: Testing server: LIBERTY, config: ALL
INFO: Testing server: LIBERTY, config: ALL_BUT_JWT_REST
INFO: Testing server: LIBERTY, config: JWT_REST
INFO: Testing server: HELIDON, config: EMPTY
INFO: Testing server: HELIDON, config: ALL
INFO: Testing server: HELIDON, config: ALL_BUT_JWT_REST
INFO: Testing server: HELIDON, config: JWT_REST
INFO: Testing server: KUMULUZEE, config: EMPTY
INFO: Testing server: KUMULUZEE, config: ALL
INFO: Testing server: KUMULUZEE, config: ALL_BUT_JWT_REST
INFO: Testing server: KUMULUZEE, config: JWT_REST
INFO: Testing server: TOMEE, config: EMPTY
INFO: Testing server: TOMEE, config: ALL
INFO: Testing server: TOMEE, config: ALL_BUT_JWT_REST
INFO: Testing server: TOMEE, config: JWT_REST
...


Results :

Tests run: 30, Failures: 0, Errors: 0, Skipped: 0


[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 08:34 min
[INFO] Finished at: 2020-01-17T16:28:23+01:00
```

It is 24 integration tests for runtimes, 1 smoke check for the API before it all goes to runtimes and 5 unit tests.

The time it takes is pretty nice, but mind you I have all the artifacts cached in my local .m2 repo and I am running it on a fairly powerful workstation. When run fresh, it obviously downloads the Internet and takes much more time.

Ping @rdebusscher @cealsair @Emily-Jiang for thoughts.

# Windows

Test suite fully supports Windows, although Payara does not pass because it doesn't start. See below.

*Windows: Tests run: 30, Failures: 4, Errors: 0, Skipped: 0*

Runtime | Windows TS status | Comment
------------ | ------------- | -------------
Thorntail | :heavy_check_mark: | 
Liberty | :heavy_check_mark:  | 
Payara | :x: | Payara issue; doesn't start
Kumuluzee | :heavy_check_mark:  | 
Tomee | :heavy_check_mark: | 

## Payara [issue 4445](https://github.com/payara/Payara/issues/4445)

Payara fails not because of the test suite, but because of Payara.
@rdebusscher , could you follow up with your peers on (no examples selected, simplest case):

```
C:\tmp\payara\demo
λ mvn clean package && java -jar target/demo-microbundle.jar
[INFO] Scanning for projects...
[INFO]
[INFO] --------------------------< com.example:demo >--------------------------
[INFO] Building demo 1.0-SNAPSHOT
[INFO] --------------------------------[ war ]---------------------------------
[INFO]
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ demo ---
[INFO]
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ demo ---
[WARNING] Using platform encoding (Cp1252 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] Copying 2 resources
[INFO]
[INFO] --- maven-compiler-plugin:3.1:compile (default-compile) @ demo ---
[INFO] Changes detected - recompiling the module!
[WARNING] File encoding has not been set, using platform encoding Cp1252, i.e. build is platform dependent!
[INFO] Compiling 2 source files to C:\tmp\payara\demo\target\classes
[INFO]
[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ demo ---
[WARNING] Using platform encoding (Cp1252 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] skip non existing resourceDirectory C:\tmp\payara\demo\src\test\resources
[INFO]
[INFO] --- maven-compiler-plugin:3.1:testCompile (default-testCompile) @ demo ---
[INFO] No sources to compile
[INFO]
[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ demo ---
[INFO] No tests to run.
[INFO]
[INFO] --- maven-war-plugin:2.2:war (default-war) @ demo ---
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.thoughtworks.xstream.core.util.Fields (file:/C:/Users/Administrator/.m2/repository/com/thoughtworks/xstream/xstream/1.3.1/xstream-1.3.1.jar) to field java.util.Properties.defaults
WARNING: Please consider reporting this to the maintainers of com.thoughtworks.xstream.core.util.Fields
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
[INFO] Packaging webapp
[INFO] Assembling webapp [demo] in [C:\tmp\payara\demo\target\demo]
[INFO] Processing war project
[INFO] Copying webapp resources [C:\tmp\payara\demo\src\main\webapp]
[INFO] Webapp assembled in [41 msecs]
[INFO] Building war: C:\tmp\payara\demo\target\demo.war
[INFO]
[INFO] --- payara-micro-maven-plugin:1.0.1:bundle (default) @ demo ---
[INFO] Configured Artifact: fish.payara.extras:payara-micro:5.194:jar
[INFO] Unpacking C:\Users\Administrator\.m2\repository\fish\payara\extras\payara-micro\5.194\payara-micro-5.194.jar to C:\tmp\payara\demo\target\extracted-payaramicro with includes "" and excludes ""
[WARNING] Using platform encoding (Cp1252 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] Copying 0 resource
[WARNING] Using platform encoding (Cp1252 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] Copying 0 resource
[INFO] Configured Artifact: com.example:demo:1.0-SNAPSHOT:war
[INFO] Copying demo.war to C:\tmp\payara\demo\target\extracted-payaramicro\MICRO-INF\deploy\ROOT.war
[INFO] Building jar: C:\tmp\payara\demo\target\demo-microbundle.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  7.567 s
[INFO] Finished at: 2020-01-20T01:59:54-08:00
[INFO] ------------------------------------------------------------------------
Jan 20, 2020 1:59:55 AM fish.payara.micro.PayaraMicro main
SEVERE: null
java.lang.reflect.InvocationTargetException
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at fish.payara.micro.boot.loader.MainMethodRunner.run(MainMethodRunner.java:50)
        at fish.payara.micro.boot.loader.Launcher.launch(Launcher.java:114)
        at fish.payara.micro.boot.loader.Launcher.launch(Launcher.java:73)
        at fish.payara.micro.boot.PayaraMicroLauncher.create(PayaraMicroLauncher.java:87)
        at fish.payara.micro.boot.PayaraMicroLauncher.main(PayaraMicroLauncher.java:71)
        at fish.payara.micro.PayaraMicro.main(PayaraMicro.java:397)
Caused by: java.lang.IllegalArgumentException: Malformed \uxxxx encoding.
        at java.base/java.util.Properties.loadConvert(Properties.java:654)
        at java.base/java.util.Properties.load0(Properties.java:454)
        at java.base/java.util.Properties.load(Properties.java:404)
        at fish.payara.micro.impl.PayaraMicroImpl.setBootProperties(PayaraMicroImpl.java:2567)
        at fish.payara.micro.impl.PayaraMicroImpl.create(PayaraMicroImpl.java:205)
        at fish.payara.micro.impl.PayaraMicroImpl.main(PayaraMicroImpl.java:200)
        ... 10 more
```

Please?  

### System
 * Windows 2019
 * OpenJDK Runtime Environment (build 11.0.1-redhat+13-LTS)
 * Apache Maven 3.6.0