### PR TITLE
Adds Quarkus to the TS, CircleCI update for TS, whitelists

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,7 @@
 version: 2.1
 executors:
   maven-builder:
-    docker:
-    - image: circleci/openjdk:11-jdk
+    machine: true
   docker-publisher:
     environment:
       IMAGE_NAME: microprofile/start.microprofile.io
@@ -23,12 +22,28 @@ jobs:
           curl -X POST -i -H "Content-Type: application/json" -H "Accept: application/json" -H "Authorization: Bearer $GITTER_TOKEN" \
           "https://api.gitter.im/v1/rooms/$GITTER_ROOM_ID/chatMessages" -d \
           "{\"text\":\"Automatic message: Hello, new [build]($CIRCLE_BUILD_URL) has started.\"}"
-    - run: mvn dependency:go-offline -Pthorntail -Djdk.net.URLClassPath.disableClassPathURLCheck=true
+    - run: if [[ ! -d ${HOME}/jdk-11.0.4+11 ]];then wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4%2B11/OpenJDK11U-jdk_x64_linux_hotspot_11.0.4_11.tar.gz;fi;
+    - run: if [[ ! -d ${HOME}/jdk-11.0.4+11 ]];then tar -xvf OpenJDK11U-jdk_x64_linux_hotspot_11.0.4_11.tar.gz -C ${HOME}/;fi;
+    - run: if [[ ! -d ${HOME}/apache-maven-3.6.3 ]];then wget https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz;fi;
+    - run: if [[ ! -d ${HOME}/apache-maven-3.6.3 ]];then tar -xvf apache-maven-3.6.3-bin.tar.gz -C ${HOME}/;fi;
+    - run:
+         name: build-fetch
+         command: |
+           export PATH=${HOME}/apache-maven-3.6.3/bin:${HOME}/jdk-11.0.4+11/bin:${PATH}; \
+           export JAVA_HOME=${HOME}/jdk-11.0.4+11/; \
+           mvn -Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2 dependency:go-offline -Pthorntail
     - save_cache:
         paths:
-        - ~/.m2
+        - ${HOME}/.m2
+        - ${HOME}/apache-maven-3.6.3
+        - ${HOME}/jdk-11.0.4+11
         key: v1-dependencies-{{ checksum "pom.xml" }}
-    - run: mvn clean package -Pthorntail -Djdk.net.URLClassPath.disableClassPathURLCheck=true
+    - run:
+        name: package-tests
+        command: |
+           export PATH=${HOME}/apache-maven-3.6.3/bin:${HOME}/jdk-11.0.4+11/bin:${PATH}; \
+           export JAVA_HOME=${HOME}/jdk-11.0.4+11/; \
+           mvn -Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2 clean package -Pthorntail -Dskip.integration.tests=false -DSTARTER_TS_WORKSPACE=/dev/shm/
     - persist_to_workspace:
         root: .
         paths:

--- a/src/it/java/org/eclipse/microprofile/starter/TestMatrixTest.java
+++ b/src/it/java/org/eclipse/microprofile/starter/TestMatrixTest.java
@@ -446,4 +446,36 @@ public class TestMatrixTest {
         testRuntime("TOMEE", "tomee",
                 SpecSelection.JWT_REST, new int[]{8009, 8005, 8180, 8109, 8105});
     }
+
+    @Test
+    @RunAsClient
+    @InSequence(25)
+    public void quarkusEmpty() throws IOException, InterruptedException {
+        testRuntime("QUARKUS", "quarkus",
+                SpecSelection.EMPTY, new int[]{9990});
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(26)
+    public void quarkusAll() throws IOException, InterruptedException {
+        testRuntime("QUARKUS", "quarkus",
+                SpecSelection.ALL, new int[]{9990, 8180, 10090});
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(27)
+    public void quarkusAllButJWTRest() throws IOException, InterruptedException {
+        testRuntime("QUARKUS", "quarkus",
+                SpecSelection.ALL_BUT_JWT_REST, new int[]{9990});
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(28)
+    public void quarkusJWTRest() throws IOException, InterruptedException {
+        testRuntime("QUARKUS", "quarkus",
+                SpecSelection.JWT_REST, new int[]{9990, 8180, 10090});
+    }
 }

--- a/src/it/java/org/eclipse/microprofile/starter/utils/Logs.java
+++ b/src/it/java/org/eclipse/microprofile/starter/utils/Logs.java
@@ -52,6 +52,8 @@ public class Logs {
             whiteList = Whitelist.KUMULUZEE.errs;
         } else if (testMethod.contains(Whitelist.TOMEE.name)) {
             whiteList = Whitelist.TOMEE.errs;
+        } else if (testMethod.contains(Whitelist.QUARKUS.name)) {
+            whiteList = Whitelist.QUARKUS.errs;
         } else {
             throw new IllegalArgumentException(
                     "testMethod as matter of convention should always contain lower-case server name, e.g. thorntail");
@@ -71,7 +73,7 @@ public class Logs {
                     }
                 }
                 assertFalse(logname + " should not contain `ERROR' lines that are not whitelisted. " +
-                                "See target" + File.separator + "archived-logs" + File.separator + testClass + File.separator + testMethod + File.separator + log.getName() + "",
+                                "See target" + File.separator + "archived-logs" + File.separator + testClass + File.separator + testMethod + File.separator + log.getName(),
                         error && !whiteListed);
             }
         }

--- a/src/it/java/org/eclipse/microprofile/starter/utils/Whitelist.java
+++ b/src/it/java/org/eclipse/microprofile/starter/utils/Whitelist.java
@@ -27,14 +27,26 @@ package org.eclipse.microprofile.starter.utils;
  * @author Michal Karm Babacek <karm@redhat.com>
  */
 public enum Whitelist {
-    THORNTAIL_V2("thorntail", new String[]{}),
-    PAYARA_MICRO("payara", new String[]{}),
+    THORNTAIL_V2("thorntail", new String[]{
+            "wildfly-domain-http-error-context"
+    }),
+    PAYARA_MICRO("payara", new String[]{
+            "com.hazelcast.nio.tcp.TcpIpConnectionErrorHandler"
+    }),
     LIBERTY("liberty", new String[]{
             "OpenTracing cannot track JAX-RS requests because an OpentracingTracerFactory class was not provided."
     }),
     HELIDON("helidon", new String[]{}),
-    KUMULUZEE("kumuluzee", new String[]{"Copying error_prone_annotations"}),
-    TOMEE("tomee", new String[]{});
+    KUMULUZEE("kumuluzee", new String[]{
+            "error_prone_annotations",
+            "error_prone_parent",
+            "underlying class loading error: Type Failure to load: com.mongodb.MongoClient not found."
+    }),
+    TOMEE("tomee", new String[]{}),
+    QUARKUS("quarkus", new String[]{
+            "[org.jboss.threads.errors] Thread Thread[build",
+            "org/jboss/threads/EnhancedQueueExecutor"
+    });
 
     public final String name;
     public final String[] errs;


### PR DESCRIPTION
Adds Quarkus to the TS, enables the TS on CircleCI and adds Kumuluzee whitelist for a new error.
Payara also got whitelisted for benign error messages unrelated to Starter (Hazelcast clustering).
Weird Quarkus ```mvn package``` error message **after** a successful build is done; also whitelisted. I was not able to even reproduce this message outside Circle CI...

It is stable and it works now. Tested cca 5 times on Circle CI.

