### PR TITLE
Circle CI: Adds timeout to maven build, adds TS to dependency:go-offline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
          command: |
            export PATH=${HOME}/apache-maven-3.6.3/bin:${HOME}/jdk-11.0.4+11/bin:${PATH}; \
            export JAVA_HOME=${HOME}/jdk-11.0.4+11/; \
-           mvn -Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2 dependency:go-offline -Pthorntail
+           mvn -Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2 dependency:go-offline -Pthorntail -Dskip.integration.tests=false
     - save_cache:
         paths:
         - ${HOME}/.m2
@@ -40,6 +40,7 @@ jobs:
         key: v1-dependencies-{{ checksum "pom.xml" }}
     - run:
         name: package-tests
+        no_output_timeout: 120000
         command: |
            export PATH=${HOME}/apache-maven-3.6.3/bin:${HOME}/jdk-11.0.4+11/bin:${PATH}; \
            export JAVA_HOME=${HOME}/jdk-11.0.4+11/; \


### PR DESCRIPTION
Sometimes the job lands on a weird VM where the
maven build hangs for many minutes with no output
to the log, e.g. 10 minutes in:

```Resolving 216 out of 524 artifacts```

If there is no output to the log for such a long time,
Cirlce CI terminates the job. To avoid these instabilities
that have nothing to do with our code,
I entered a bigger timeout. It seems to fix the problem
according to the last trial.

Signed-off-by: Michal Karm Babacek <karm@fedoraproject.org>