### PR TITLE
Thorntail 2.7.0 for MP 3.3, WildFly 19.1.0.Final, Quarkus 1.3.4.Final

### DIFF
--- a/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/model/SupportedServer.java
+++ b/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/model/SupportedServer.java
@@ -39,7 +39,7 @@ public enum SupportedServer {
             , null // MP Spec for Java 11 support
     ), THORNTAIL_V2("thorntail-v2", "Thorntail V2",
             Arrays.asList(MicroProfileVersion.MP12, MicroProfileVersion.MP13, MicroProfileVersion.MP21,
-                    MicroProfileVersion.MP22, MicroProfileVersion.MP30, MicroProfileVersion.MP32)
+                    MicroProfileVersion.MP22, MicroProfileVersion.MP30, MicroProfileVersion.MP32, MicroProfileVersion.MP33)
             , "%s-thorntail.jar" //jarFileName
             , "-Dswarm.port.offset=100" //jarParameters
             , "8080" //portServiceA

--- a/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/server/QuarkusServer.java
+++ b/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/server/QuarkusServer.java
@@ -94,7 +94,7 @@ public class QuarkusServer extends AbstractMicroprofileAddon {
             case NONE:
                 break;
             case MP32:
-                quarkusVersion = "1.3.0.Final";
+                quarkusVersion = "1.3.4.Final";
                 break;
             case MP30:
                 break;

--- a/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/server/ThorntailServer.java
+++ b/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/server/ThorntailServer.java
@@ -80,8 +80,11 @@ public class ThorntailServer extends AbstractMicroprofileAddon {
 
             case NONE:
                 break;
+            case MP33:
+                thorntailVersion = "2.7.0.Final";
+                break;
             case MP32:
-                thorntailVersion = "2.6.0.Final";
+                thorntailVersion = "2.7.0.Final";
                 break;
             case MP30:
                 thorntailVersion = "2.5.0.Final";

--- a/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/server/WildFlyServer.java
+++ b/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/server/WildFlyServer.java
@@ -86,7 +86,7 @@ public class WildFlyServer extends AbstractMicroprofileAddon {
             case NONE:
                 break;
             case MP33:
-                wildflyVersion = "19.0.0.Final";
+                wildflyVersion = "19.1.0.Final";
                 break;
             case MP32:
                 wildflyVersion = "19.0.0.Final";


### PR DESCRIPTION
Adds Thorntail 2.7 to MP 3.3 and other version bumps.

This PR **does not** close Issue 303 as Quarkus is not listed on https://wiki.eclipse.org/MicroProfile/Implementation for MP 3.3 now due to ongoing disputes.