### PR TITLE
Quarkus 1.7.0.Final, JWT lib token generation to Vert.x JWT 3.9.2

### DIFF
--- a/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/MicroprofileServersAddon.java
+++ b/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/MicroprofileServersAddon.java
@@ -57,7 +57,7 @@ public class MicroprofileServersAddon extends AbstractMicroprofileAddon {
 
     private List<MicroprofileSpec> microprofileSpecs;
 
-    private static final String VERTX_JWT_VERSION = "3.8.1";
+    private static final String VERTX_JWT_VERSION = "3.9.2";
 
     @PostConstruct
     public void init() {

--- a/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/server/QuarkusServer.java
+++ b/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/server/QuarkusServer.java
@@ -19,6 +19,7 @@
  */
 package org.eclipse.microprofile.starter.addon.microprofile.servers.server;
 
+import org.apache.maven.model.ActivationProperty;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Profile;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
@@ -94,7 +95,7 @@ public class QuarkusServer extends AbstractMicroprofileAddon {
             case NONE:
                 break;
             case MP32:
-                quarkusVersion = "1.3.4.Final";
+                quarkusVersion = "1.7.0.Final";
                 break;
             case MP30:
                 break;
@@ -113,11 +114,16 @@ public class QuarkusServer extends AbstractMicroprofileAddon {
             default:
         }
         pomFile.addProperty("version.quarkus", quarkusVersion);
+        pomFile.setPackaging("jar");
         List<MicroprofileSpec> microprofileSpecs = model.getParameter(JessieModel.Parameter.MICROPROFILESPECS);
 
         Profile nativeProfile = pomFile.getProfiles().get(0).clone();
         nativeProfile.setId("native");
         nativeProfile.getActivation().setActiveByDefault(false);
+        ActivationProperty activationPropertyNative = new ActivationProperty();
+        activationPropertyNative.setName("name");
+        activationPropertyNative.setValue("native");
+        nativeProfile.getActivation().setProperty(activationPropertyNative);
         nativeProfile.getBuild().getPlugins().get(0).getExecutions().get(0).setGoals(Collections.singletonList("native-image"));
 
         Xpp3Dom configuration = new Xpp3Dom("configuration");

--- a/src/main/resources/files/TestSecureController.java.tpl
+++ b/src/main/resources/files/TestSecureController.java.tpl
@@ -1,10 +1,9 @@
 package [# th:text="${java_package}"/].secure;
 
-import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.JWTOptions;
 import io.vertx.ext.auth.PubSecKeyOptions;
 import io.vertx.ext.auth.jwt.JWTAuth;
 import io.vertx.ext.auth.jwt.JWTAuthOptions;
-import io.vertx.ext.jwt.JWTOptions;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
@@ -67,7 +66,7 @@ public class TestSecureController {
 
         token.setGroups(Arrays.asList("user", "protected"));
 
-        return provider.generateToken(new JsonObject().mergeIn(token.toJSONString()), new JWTOptions().setAlgorithm("RS256"));
+        return provider.generateToken(new io.vertx.core.json.JsonObject().mergeIn(token.toJSONString()), new JWTOptions().setAlgorithm("RS256"));
     }
 
     // NOTE:   Expected format is PKCS#8 (BEGIN PRIVATE KEY) NOT PKCS#1 (BEGIN RSA PRIVATE KEY)

--- a/src/main/resources/files/quarkus/readme.md.secondary.tpl
+++ b/src/main/resources/files/quarkus/readme.md.secondary.tpl
@@ -6,7 +6,7 @@ MicroProfile Starter has generated this MicroProfile application for you contain
 
 The generation of the executable jar file can be performed by issuing the following command
 
-    mvn clean compile quarkus:build
+    mvn clean compile package
 
 This will create a jar file **[# th:text="${jar_file}"/]** within the _target_ maven folder. This can be started by executing the following command
 
@@ -18,7 +18,7 @@ You can also start the project in development mode where it automatically update
 
 Last but not least, you can build the whole application into a one statically linked executable that does not require JVM:
 
-    mvn clean compile quarkus:native-image -Pnative
+    mvn clean compile package -Pnative
 
 Native executable build might take a minute. Then you can execute it on a compatible architecture without JVM:
 

--- a/src/main/resources/files/quarkus/readme.md.tpl
+++ b/src/main/resources/files/quarkus/readme.md.tpl
@@ -6,7 +6,7 @@ MicroProfile Starter has generated this MicroProfile application for you.
 
 The generation of the executable jar file can be performed by issuing the following command
 
-    mvn clean compile quarkus:build
+    mvn clean compile package
 
 This will create a jar file **[# th:text="${jar_file}"/]** within the _target_ maven folder. This can be started by executing the following command
 
@@ -18,7 +18,7 @@ You can also start the project in development mode where it automatically update
 
 Last but not least, you can build the whole application into a one statically linked executable that does not require JVM:
 
-    mvn clean compile quarkus:native-image -Pnative
+    mvn clean compile package -Pnative
 
 Native executable build might take a minute. Then you can execute it on a compatible architecture without JVM:
 

--- a/src/main/resources/pom-servers.xml
+++ b/src/main/resources/pom-servers.xml
@@ -179,7 +179,7 @@
                 <dependencies>
                     <dependency>
                         <groupId>io.quarkus</groupId>
-                        <artifactId>quarkus-bom</artifactId>
+                        <artifactId>quarkus-universe-bom</artifactId>
                         <version>${version.quarkus}</version>
                         <type>pom</type>
                         <scope>import</scope>
@@ -187,7 +187,6 @@
                 </dependencies>
             </dependencyManagement>
             <dependencies>
-
             </dependencies>
             <build>
                 <plugins>
@@ -198,10 +197,15 @@
                         <executions>
                             <execution>
                                 <goals>
+                                    <goal>prepare</goal>
                                     <goal>build</goal>
                                 </goals>
                             </execution>
                         </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>3.8.1</version>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
This patch modernizes Quarkus generator to be on par with
what is deemed valid for Quarkus 1.7.0.final. Both JVM and Native
modes work. It also ports JWT example code to use Vert.x JWT 3.9.2.

All runtimes run with it. The only test failure recorded was
Liberty's mysterious error message unrelated to this patch (occured before),
which is tracked here: issues/328 #328

Signed-off-by: Michal Karm Babacek <karm@fedoraproject.org>