### PR TITLE
[353] Add Liberty profile for build/deploy

### DIFF
--- a/Container/README.md
+++ b/Container/README.md
@@ -14,6 +14,10 @@ mvn thorntail:run -Pthorntail
 
 Navigate to 127.0.0.1:8080 or http://127.0.0.1:8080/index.xhtml to see the app.
 
+It is also possible to build and deploy to Open Liberty using the Liberty profile. To build the MP Starter
+app, use: `mvn package liberty:run -Pliberty ` and then browse to http://localhost:9080/mp-starter/ to test
+the app.
+
 Docker build
 ------------
 With at least Docker 17.05, one can build an image and either run it locally or push it to a registry.

--- a/README.md
+++ b/README.md
@@ -31,3 +31,5 @@ Information about adding
 * a new MicroProfile Specification
 
 is found in the [how to document](https://github.com/eclipse/microprofile-starter/blob/master/how-to.md).
+
+It is also possible to build and deploy to Open Liberty using the Liberty profile. To build the MP Starter app, use: `mvn package -Pliberty liberty:run` and then browse to http://localhost:9080/mp-starter/ to test the app.

--- a/README.md
+++ b/README.md
@@ -31,5 +31,3 @@ Information about adding
 * a new MicroProfile Specification
 
 is found in the [how to document](https://github.com/eclipse/microprofile-starter/blob/master/how-to.md).
-
-It is also possible to build and deploy to Open Liberty using the Liberty profile. To build the MP Starter app, use: `mvn package -Pliberty liberty:run` and then browse to http://localhost:9080/mp-starter/ to test the app.

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
         <thymeleaf.version>3.0.10.RELEASE</thymeleaf.version>
         <junit.version>4.12</junit.version>
         <resteasy.version>4.3.0.Final</resteasy.version>
+        <openliberty.maven.version>3.2</openliberty.maven.version>
 
         <checkstyle.version>2.17</checkstyle.version>
         <checkstyle.methodNameFormat>^_?[a-z][a-zA-Z0-9]*$</checkstyle.methodNameFormat>
@@ -364,6 +365,67 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>liberty</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <skipTests>true</skipTests>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.openliberty.tools</groupId>
+                        <artifactId>liberty-maven-plugin</artifactId>
+                        <version>${openliberty.maven.version}</version>
+                        <executions>
+                            <execution>
+                                <id>package-server</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>create</goal>
+                                    <goal>install-feature</goal>
+                                    <goal>deploy</goal>
+                                    <goal>package</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>target/wlp-package</outputDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <skipTests>${skipTests}</skipTests>
+                            <include>runnable</include>
+                            <serverName>${final.name}</serverName>
+                            <bootstrapProperties>
+                                <project.name>${final.name}</project.name>
+                            </bootstrapProperties>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.arquillian.container</groupId>
+                    <artifactId>arquillian-container-test-api</artifactId>
+                    <version>1.6.0.Final</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.arquillian.junit</groupId>
+                    <artifactId>arquillian-junit-container</artifactId>
+                    <version>1.6.0.Final</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.wildfly.swarm</groupId>
+                    <artifactId>arquillian</artifactId>
+                    <version>2018.5.0</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
     </profiles>
 </project>

--- a/src/main/liberty/config/server.xml
+++ b/src/main/liberty/config/server.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server description="new server">
+
+    <!-- Enable features -->
+    <featureManager>
+        <feature>microprofile-3.3</feature>
+        <feature>webprofile-8.0</feature>
+    </featureManager>
+
+    <!-- To access this server from a remote client add a host attribute to the following element, e.g. host="*" -->
+    <httpEndpoint id="defaultHttpEndpoint"
+                  httpPort="9080"
+                  httpsPort="9443" />
+
+    <!-- Automatically expand WAR files and EAR files -->
+    <applicationManager autoExpand="true"/>
+
+    <!-- Default SSL configuration enables trust for default certificates from the Java runtime --> 
+    <ssl id="defaultSSLConfig" trustDefaultCerts="true" />
+</server>


### PR DESCRIPTION
Adds liberty maven profile to quickly build and deploy to Open Liberty server for manual testing. Closes #353. 