### PR TITLE
ignore case for spec codes

### DIFF
--- a/src/it/java/org/eclipse/microprofile/starter/utils/Commands.java
+++ b/src/it/java/org/eclipse/microprofile/starter/utils/Commands.java
@@ -67,7 +67,9 @@ public class Commands {
     }
 
     public static void download(Client client, String supportedServer, String artifactId, SpecSelection specSelection, String location) {
-        Response response = client.target(API_URL + "/project?supportedServer=" + supportedServer + specSelection.queryParam + "&artifactId=" + artifactId).request().get();
+        String uri = API_URL + "/project?supportedServer=" + supportedServer + specSelection.queryParam + "&artifactId=" + artifactId;
+        LOGGER.info("from " + uri);
+        Response response = client.target(uri).request().get();
         assertEquals("Download failed.", Response.Status.OK.getStatusCode(), response.getStatus());
         try (FileOutputStream out = new FileOutputStream(location); InputStream in = (InputStream) response.getEntity()) {
             in.transferTo(out);

--- a/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/model/MicroprofileSpec.java
+++ b/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/model/MicroprofileSpec.java
@@ -118,7 +118,7 @@ public enum MicroprofileSpec {
     public static MicroprofileSpec valueFor(String data) {
         MicroprofileSpec result = null;
         for (MicroprofileSpec spec : MicroprofileSpec.values()) {
-            if (spec.code.equals(data)) {
+            if (spec.code.equalsIgnoreCase(data)) {
                 result = spec;
             }
         }

--- a/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/model/StandaloneMPSpec.java
+++ b/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/model/StandaloneMPSpec.java
@@ -96,7 +96,7 @@ public enum StandaloneMPSpec {
     public static StandaloneMPSpec valueFor(String data) {
         StandaloneMPSpec result = null;
         for (StandaloneMPSpec spec : StandaloneMPSpec.values()) {
-            if (spec.code.equals(data)) {
+            if (spec.code.equalsIgnoreCase(data)) {
                 result = spec;
             }
         }


### PR DESCRIPTION
This fixes most test cases except the Helidon one as the generated project can no longer be compiled with Java 8.

see https://github.com/eclipse/microprofile-starter/issues/361