### PR TITLE
Fix configuration variables for context root

### DIFF
--- a/src/main/resources/files/gradle/liberty/build.gradle.tpl
+++ b/src/main/resources/files/gradle/liberty/build.gradle.tpl
@@ -1,6 +1,7 @@
 apply plugin: 'war'
 apply plugin: 'liberty'
 
+def projectName = '[# th:text="${maven_artifactid}"/]'
 group = '[# th:text="${maven_groupid}"/]'
 version = '1.0-SNAPSHOT'
 
@@ -11,6 +12,10 @@ targetCompatibility = [# th:text="${se_version}"/]
 
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
+}
+
+war {
+    archiveName = projectName + '.war'
 }
 
 // configure liberty-gradle-plugin
@@ -36,6 +41,7 @@ dependencies {
 
 ext  {
     liberty.server.var.'default.http.port' = '[# th:text="${port_service}"/]'
+    liberty.server.var.'project.name' = projectName
     liberty.server.var.'app.context.root' = '/'
 }
 

--- a/src/main/resources/files/liberty/server.xml.tpl
+++ b/src/main/resources/files/liberty/server.xml.tpl
@@ -15,7 +15,7 @@
                   httpPort="[# th:text="${port_service_a}"/]"
                   httpsPort="9443"/>
 
-    <webApplication location="${project.name}.war" contextRoot="/">
+    <webApplication location="${project.name}.war" contextRoot="${app.context.root}">
         <classloader apiTypeVisibility="+third-party" />
     </webApplication>
     <mpMetrics authentication="false"/>

--- a/src/main/resources/files/liberty/service-b/server.xml.tpl
+++ b/src/main/resources/files/liberty/service-b/server.xml.tpl
@@ -10,7 +10,7 @@
                   httpPort="[# th:text="${port_service_b}"/]"
                   httpsPort="9444"/>
 
-    <webApplication location="${project.name}.war" contextRoot="/">
+    <webApplication location="${project.name}.war" contextRoot="${app.context.root}">
         <classloader apiTypeVisibility="+third-party" />
     </webApplication>
     <mpMetrics authentication="false"/>


### PR DESCRIPTION
1) Name the output file demo.war (the .xml added to the actual file in wlp/liberty/apps becuase this project uses filesystem deployment can be ignored)

2) Add a liberty server configuration variable "project.name" so that the webApplication element in server.xml will point to the application. Without it the gradle plugin will see it has not deployed the app and fall back to deploying via dropins. A dropins deployment will always use a default context root

3) Set the context root in server.xml to ${app.context.root} so it reads from build.gradle rather than is hardcoded to "/"

(1 and 2 are acomplished via a common variable to keep them in sync)