### PR TITLE
Use Helidon 2.3.0 for MP 3.3

### DIFF
--- a/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/server/HelidonServer.java
+++ b/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/server/HelidonServer.java
@@ -123,7 +123,7 @@ public class HelidonServer extends AbstractMicroprofileAddon {
             case NONE:
                 break;
             case MP33:
-                helidonVersion = "2.2.1";
+                helidonVersion = "2.3.0";
                 mpVersion = "3.3";
                 break;
             case MP32:


### PR DESCRIPTION
Resolves #419 
Resolves https://github.com/oracle/helidon/issues/2980

Helidon has just released 2.3.0, the latest version which supports MP 3.3.

This change has the starter use Helidon 2.3.0 for generated Helidon apps.

Signed-off-by: tim.quinn@oracle.com <tim.quinn@oracle.com>