### PR TITLE
Quarkus 1.7.0.Final -> 1.7.6.Final , Gradle support, CI, WildFly versions match MP versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: MicroProfile Starter Tests
+name: Tests
 
 on:
   push:
@@ -31,7 +31,7 @@ env:
 
 jobs:
   run-starter:
-    name: MicroProfile Starter ${{ matrix.runtime }}
+    name: ${{ matrix.runtime }} MicroProfile Starter
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
@@ -69,14 +69,14 @@ jobs:
         check-latest: true
     - name: Build and run tests for Starter
       run: |
-        mvn clean verify -Pthorntail -Dtest=TestMatrixTest#${{ matrix.runtime }}*
+        mvn clean verify -Pthorntail -Dtest=TestMatrixTest#${{ matrix.runtime }}* -DSTARTER_TS_WORKSPACE=$RUNNER_TEMP
     - name: Prepare failure archive (if maven failed)
       if: failure()
       shell: bash
-      run: find . -type d -name '*-reports' -o -name "*.log" | tar -czf test-reports.tgz -T -
+      run: find . -type d -name '*-reports' -o -name "*.log" | tar -czf test-reports-${{ matrix.runtime }}.tgz -T -
     - name: Upload failure Archive (if maven failed)
       uses: actions/upload-artifact@v2
       if: failure()
       with:
-        name: test-reports
-        path: 'test-reports.tgz'
+        name: test-reports-${{ matrix.runtime }}
+        path: 'test-reports-${{ matrix.runtime }}.tgz'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,50 +27,56 @@ on:
 
 env:
   LANG: en_US.UTF-8
-  JAVA_HOME: ${{ github.workspace }}/openjdk
-  
+  GRADLE_USER_HOME: ~/.gradle
+
 jobs:
   run-starter:
-    name: MicroProfile Starter build and test - ${{ matrix.jdk }}
-    runs-on: ubuntu-18.04
+    name: MicroProfile Starter ${{ matrix.runtime }}
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
-        jdk: ['OpenJDK11-latest-GA']
-        include:
-          - jdk: 'OpenJDK11-latest-GA'
-            release_type: 'ga'
+        runtime: [ 'helidon',
+                   'kumuluzee',
+                   'liberty',
+                   'payara',
+                   'quarkus',
+                   'thorntail',
+                   'tomee',
+                   'wildfly' ]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         fetch-depth: 1
-        path: starter
-    - uses: actions/cache@v1
+    - uses: actions/cache@v2
       with:
         path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        key: ${{ runner.os }}-${{ matrix.runtime }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          ${{ runner.os }}-maven-
-    - name: Get OpenJDK 11
-      run: |
-        curl -sL https://api.adoptopenjdk.net/v3/binary/latest/11/${{ matrix.release_type }}/linux/x64/jdk/hotspot/normal/openjdk -o jdk.tar.gz
-        mkdir -p ${JAVA_HOME}
-        tar xf jdk.tar.gz -C ${JAVA_HOME} --strip-components=1
-        echo ${JAVA_HOME}
-        ${JAVA_HOME}/bin/java --version
+          ${{ runner.os }}-${{ matrix.runtime }}-maven-
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-${{ matrix.runtime }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.runtime }}-gradle-
+    - uses: actions/setup-java@v2
+      with:
+        distribution: 'adopt'
+        java-version: '11'
+        check-latest: true
     - name: Build and run tests for Starter
       run: |
-        cd ${{ github.workspace }}
-        export PATH=${JAVA_HOME}/bin:${PATH}
-        mvn clean verify -Pthorntail
+        mvn clean verify -Pthorntail -Dtest=TestMatrixTest#${{ matrix.runtime }}*
     - name: Prepare failure archive (if maven failed)
       if: failure()
       shell: bash
-      run: find . -type d -name '*-reports' -o -wholename '*/build/reports/tests/functionalTest' -o -name "*.log" | tar -czf test-reports.tgz -T -
+      run: find . -type d -name '*-reports' -o -name "*.log" | tar -czf test-reports.tgz -T -
     - name: Upload failure Archive (if maven failed)
       uses: actions/upload-artifact@v2
       if: failure()
       with:
         name: test-reports
         path: 'test-reports.tgz'
- 

--- a/pom.xml
+++ b/pom.xml
@@ -328,13 +328,6 @@
                     <scope>test</scope>
                 </dependency>
 
-                <dependency>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                    <version>${junit.version}</version>
-                    <scope>test</scope>
-                </dependency>
-
             </dependencies>
 
             <dependencyManagement>

--- a/src/it/java/org/eclipse/microprofile/starter/TestMatrixTest.java
+++ b/src/it/java/org/eclipse/microprofile/starter/TestMatrixTest.java
@@ -236,10 +236,6 @@ public class TestMatrixTest {
         } else if (supportedServer.equalsIgnoreCase("WILDFLY")) {
             // Wildfly has a special port
             specialUrlBase = urlBase.replace(SupportedServer.WILDFLY.getPortServiceA(), "9990");
-        // Pertinent for Q 2.x+, also in index.html
-        //} else if (supportedServer.equalsIgnoreCase("QUARKUS")) {
-        //    // Quarkus prepends /q
-        //    specialUrlBase = urlBase + "q/";
         } else {
             specialUrlBase = urlBase;
         }
@@ -259,7 +255,7 @@ public class TestMatrixTest {
             testWeb(urlBase + MPSpecGET.METRICS.urlContent[0][0], 5, MPSpecGET.METRICS.urlContent[0][1]);
             testWeb(specialUrlBase + MPSpecGET.METRICS.urlContent[1][0], 10, MPSpecGET.METRICS.urlContent[1][1]);
             testWeb(urlBase + MPSpecGET.JWT_AUTH.urlContent[0][0], 5, MPSpecGET.JWT_AUTH.urlContent[0][1]);
-            if (supportedServer.equalsIgnoreCase("TOMEE") || supportedServer.equalsIgnoreCase("QUARKUS")) {
+            if (supportedServer.equalsIgnoreCase("TOMEE")) {
                 testWeb(specialUrlBase + MPSpecGET.OPEN_API.urlContent[0][0], 5, MPSpecGET.OPEN_API.urlContent[0][1]);
             } else {
                 testWeb(urlBase + MPSpecGET.OPEN_API.urlContent[0][0], 5, MPSpecGET.OPEN_API.urlContent[0][1]);
@@ -274,7 +270,7 @@ public class TestMatrixTest {
             testWeb(specialUrlBase + MPSpecGET.HEALTH_CHECKS.urlContent[0][0], 5, MPSpecGET.HEALTH_CHECKS.urlContent[0][1]);
             testWeb(urlBase + MPSpecGET.METRICS.urlContent[0][0], 5, MPSpecGET.METRICS.urlContent[0][1]);
             testWeb(specialUrlBase + MPSpecGET.METRICS.urlContent[1][0], 5, MPSpecGET.METRICS.urlContent[1][1]);
-            if (supportedServer.equalsIgnoreCase("TOMEE") || supportedServer.equalsIgnoreCase("QUARKUS")) {
+            if (supportedServer.equalsIgnoreCase("TOMEE")) {
                 testWeb(specialUrlBase + MPSpecGET.OPEN_API.urlContent[0][0], 5, MPSpecGET.OPEN_API.urlContent[0][1]);
             } else {
                 testWeb(urlBase + MPSpecGET.OPEN_API.urlContent[0][0], 5, MPSpecGET.OPEN_API.urlContent[0][1]);

--- a/src/it/java/org/eclipse/microprofile/starter/utils/Whitelist.java
+++ b/src/it/java/org/eclipse/microprofile/starter/utils/Whitelist.java
@@ -54,11 +54,20 @@ public enum Whitelist {
     }),
     TOMEE("tomee", new Pattern[]{}),
     QUARKUS("quarkus", new Pattern[]{
+            Pattern.compile(".*error_prone_annotations.*"),
+            Pattern.compile(".*error_prone_parent.*"),
             Pattern.compile(".*\\[org.jboss.threads.errors] Thread Thread\\[build.*"),
             Pattern.compile(".*org/jboss/threads/EnhancedQueueExecutor.*"),
+            // If there is nobody to receive traces, there is a log about it.
+            Pattern.compile(".*io.jaegertracing.internal.exceptions.SenderException.*"),
     }),
     WILDFLY("wildfly", new Pattern[]{
+            Pattern.compile(".*error_prone_annotations.*"),
+            Pattern.compile(".*error_prone_parent.*"),
             Pattern.compile(".*wildfly-domain-http-error-context.*"),
+            // Known warning, needs WF update
+            Pattern.compile(".*io/netty/util/internal/logging/Log4J2Logger.*"),
+            Pattern.compile(".*io.undertow.servlet.handlers.SendErrorPageHandler.*"),
     });
 
     public final String name;

--- a/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/MicroprofileServersAddon.java
+++ b/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/MicroprofileServersAddon.java
@@ -59,7 +59,7 @@ public class MicroprofileServersAddon extends AbstractMicroprofileAddon {
     private List<MicroprofileSpec> microprofileSpecs;
     private List<StandaloneMPSpec> microprofileStandaloneSpecs;
 
-    private static final String VERTX_JWT_VERSION = "3.9.2";
+    public static final String VERTX_JWT_VERSION = "3.9.5";
 
     @PostConstruct
     public void init() {

--- a/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/model/JDKSelector.java
+++ b/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/model/JDKSelector.java
@@ -44,6 +44,7 @@ public class JDKSelector {
         fillJavaSEVersion(data, SupportedServer.THORNTAIL_V2, JavaSEVersion.SE11, MicroProfileVersion.MP22, null);  // Supported from MP 2.2
 
         fillJavaSEVersion(data, SupportedServer.QUARKUS, JavaSEVersion.SE8, null, null);  // Supported for all MPVersions
+        fillJavaSEVersion(data, SupportedServer.QUARKUS, JavaSEVersion.SE11,  MicroProfileVersion.MP32, null);  // Supported for all MPVersions
 
         fillJavaSEVersion(data, SupportedServer.WILDFLY, JavaSEVersion.SE8, null, null);  // Supported for all MPVersions
         fillJavaSEVersion(data, SupportedServer.WILDFLY, JavaSEVersion.SE11, MicroProfileVersion.MP32, null);  // Supported from MP 3.2

--- a/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/model/JDKSelector.java
+++ b/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/model/JDKSelector.java
@@ -44,7 +44,7 @@ public class JDKSelector {
         fillJavaSEVersion(data, SupportedServer.THORNTAIL_V2, JavaSEVersion.SE11, MicroProfileVersion.MP22, null);  // Supported from MP 2.2
 
         fillJavaSEVersion(data, SupportedServer.QUARKUS, JavaSEVersion.SE8, null, null);  // Supported for all MPVersions
-        fillJavaSEVersion(data, SupportedServer.QUARKUS, JavaSEVersion.SE11,  MicroProfileVersion.MP32, null);  // Supported for all MPVersions
+        fillJavaSEVersion(data, SupportedServer.QUARKUS, JavaSEVersion.SE11,  MicroProfileVersion.MP32, null);  // Supported from MP 3.2
 
         fillJavaSEVersion(data, SupportedServer.WILDFLY, JavaSEVersion.SE8, null, null);  // Supported for all MPVersions
         fillJavaSEVersion(data, SupportedServer.WILDFLY, JavaSEVersion.SE11, MicroProfileVersion.MP32, null);  // Supported from MP 3.2

--- a/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/model/SupportedServer.java
+++ b/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/model/SupportedServer.java
@@ -54,10 +54,10 @@ public enum SupportedServer {
             , "8080" //portServiceA
             , "8180" //portServiceB
             , "https://quarkus.io/"
-            , false)  // GradleSupport
+            , true)  // GradleSupport
     , WILDFLY("wildfly", "WildFly",
             Arrays.asList(MicroProfileVersion.MP32, MicroProfileVersion.MP33, MicroProfileVersion.MP40)
-            , "%s-wildfly.jar" //jarFileName
+            , "%s-bootable.jar" //jarFileName
             , "-Djboss.socket.binding.port-offset=100" //jarParameters
             , "8080" //portServiceA
             , "8180" //portServiceB

--- a/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/server/HelidonServer.java
+++ b/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/server/HelidonServer.java
@@ -33,10 +33,10 @@ import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.HashSet;
 
 @ApplicationScoped
 public class HelidonServer extends AbstractMicroprofileAddon {
@@ -94,7 +94,7 @@ public class HelidonServer extends AbstractMicroprofileAddon {
             Set<String> tempAlternative = new HashSet<>(alternatives);
             tempAlternative.add(JessieModel.SECONDARY_INDICATOR);
             templateEngine.processTemplateFile(viewDirectory,
-                    "RestApplication.java",variables.get("application") + "RestApplication.java", tempAlternative, variables);
+                    "RestApplication.java", variables.get("application") + "RestApplication.java", tempAlternative, variables);
 
             String bResourcesDir = model.getDirectory(false) + "/" + MavenCreator.SRC_MAIN_RESOURCES;
             String bResourcesMETAINFDir = bResourcesDir + "/META-INF";

--- a/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/server/WildFlyServer.java
+++ b/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/server/WildFlyServer.java
@@ -82,37 +82,7 @@ public class WildFlyServer extends AbstractMicroprofileAddon {
 
     @Override
     public void adaptMavenModel(Model pomFile, JessieModel model, boolean mainProject) {
-        String wildflyVersion = "";
-        switch (model.getSpecification().getMicroProfileVersion()) {
-
-            case NONE:
-                break;
-            case MP40:
-                wildflyVersion = "23.0.0.Final";
-                break;
-            case MP33:
-                wildflyVersion = "19.1.0.Final";
-                break;
-            case MP32:
-                wildflyVersion = "19.0.0.Final";
-                break;
-            case MP30:
-                break;
-            case MP22:
-                break;
-            case MP21:
-                break;
-            case MP20:
-                break;
-            case MP14:
-                break;
-            case MP13:
-                break;
-            case MP12:
-                break;
-            default:
-        }
-        pomFile.addProperty("version.wildfly", wildflyVersion);
+        pomFile.addProperty("version.wildfly", defineWildFlyVersion(model));
         List<MicroprofileSpec> microprofileSpecs = model.getParameter(JessieModel.Parameter.MICROPROFILESPECS);
         Xpp3Dom configuration = (Xpp3Dom) pomFile.getProfiles().get(0).getBuild().getPlugins()
                 .get(0).getConfiguration();
@@ -158,7 +128,7 @@ public class WildFlyServer extends AbstractMicroprofileAddon {
             layer.setValue("open-tracing");
             layers.addChild(layer);
         }
-        if((microprofileSpecs.contains(MicroprofileSpec.REST_CLIENT) ||
+        if ((microprofileSpecs.contains(MicroprofileSpec.REST_CLIENT) ||
                 microprofileSpecs.contains(MicroprofileSpec.JWT_AUTH)) &&
                 mainProject && !microprofileSpecs.contains(MicroprofileSpec.CONFIG)) {
             layer = new Xpp3Dom("layer");
@@ -166,5 +136,32 @@ public class WildFlyServer extends AbstractMicroprofileAddon {
             layers.addChild(layer);
         }
         configuration.addChild(layers);
+    }
+
+    private String defineWildFlyVersion(JessieModel model) {
+        switch (model.getSpecification().getMicroProfileVersion()) {
+            case NONE:
+                break;
+            case MP40:
+                return "23.0.2.Final";
+            case MP33:
+                return "20.0.0.Final";
+            case MP32:
+                return "20.0.0.Final";
+            case MP22:
+                break;
+            case MP21:
+                break;
+            case MP20:
+                break;
+            case MP14:
+                break;
+            case MP13:
+                break;
+            case MP12:
+                break;
+            default:
+        }
+        return null;
     }
 }

--- a/src/main/java/org/eclipse/microprofile/starter/core/TemplateVariableProvider.java
+++ b/src/main/java/org/eclipse/microprofile/starter/core/TemplateVariableProvider.java
@@ -23,6 +23,7 @@
 package org.eclipse.microprofile.starter.core;
 
 import org.apache.commons.lang3.StringUtils;
+import org.eclipse.microprofile.starter.core.model.BuildTool;
 import org.eclipse.microprofile.starter.core.model.JavaSEVersion;
 import org.eclipse.microprofile.starter.core.model.JessieModel;
 
@@ -53,8 +54,14 @@ public class TemplateVariableProvider {
         result.put("secondary_project", model.hasMainAndSecondaryProject() ? "true" : "false");
 
         JavaSEVersion seVersion = model.getSpecification().getJavaSEVersion();
-        result.put("se_version", seVersion.getCode());
+        if (model.getSpecification().getBuildTool() == BuildTool.GRADLE) {
+            // Gradle:
+            // Good: sourceCompatibility = JavaVersion.VERSION_1_8
+            // No-good: sourceCompatibility = JavaVersion.VERSION_1.8
+            result.put("se_version", seVersion.getCode().replace(".", "_"));
+        } else {
+            result.put("se_version", seVersion.getCode());
+        }
         return result;
-
     }
 }

--- a/src/main/java/org/eclipse/microprofile/starter/core/addon/AddonManager.java
+++ b/src/main/java/org/eclipse/microprofile/starter/core/addon/AddonManager.java
@@ -79,8 +79,8 @@ public class AddonManager {
 
     public List<JessieGradleAdapter> getGradleAdapters() {
 
-        Iterator<JessieGradleAdapter> mavenAdapterIterator = gradleAdapters.iterator();
-        return getProviders(mavenAdapterIterator);
+        Iterator<JessieGradleAdapter> gradleAdapterIterator = gradleAdapters.iterator();
+        return getProviders(gradleAdapterIterator);
     }
 
     private <T> List<T> getProviders(Iterator<T> alternativesIterator) {

--- a/src/main/java/org/eclipse/microprofile/starter/core/artifacts/GradleCreator.java
+++ b/src/main/java/org/eclipse/microprofile/starter/core/artifacts/GradleCreator.java
@@ -22,6 +22,7 @@
  */
 package org.eclipse.microprofile.starter.core.artifacts;
 
+import org.eclipse.microprofile.starter.addon.microprofile.servers.model.MicroprofileSpec;
 import org.eclipse.microprofile.starter.core.addon.AddonManager;
 import org.eclipse.microprofile.starter.core.model.JessieModel;
 import org.eclipse.microprofile.starter.spi.JessieAddon;
@@ -35,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.eclipse.microprofile.starter.addon.microprofile.servers.MicroprofileServersAddon.VERTX_JWT_VERSION;
 import static org.eclipse.microprofile.starter.core.model.JessieModel.MAIN_INDICATOR;
 
 /**
@@ -65,7 +67,6 @@ public class GradleCreator extends BuildToolCreator {
         alternatives.add("gradle");  // So that files can be placed in a separate directory
 
         if (!mainProject) {
-
             alternatives.add(JessieModel.SECONDARY_INDICATOR);
         }
 
@@ -87,7 +88,11 @@ public class GradleCreator extends BuildToolCreator {
         } else {
             variables.put("mainProject", "false");
         }
+        if (variables.containsKey("mp_" + MicroprofileSpec.JWT_AUTH.getCode())) {
+            variables.put("vertx_auth_jwt_version", VERTX_JWT_VERSION);
+        }
         templateEngine.processTemplateFile(rootDirectory, "build.gradle", alternatives, variables);
+        templateEngine.processTemplateFile(rootDirectory, "gradle.properties", alternatives, variables);
         templateEngine.processTemplateFile(rootDirectory, "settings.gradle", alternatives, variables);
     }
 

--- a/src/main/resources/files.lst
+++ b/src/main/resources/files.lst
@@ -13,6 +13,9 @@ src/main/resources/files/gradle/gradlew.tpl
 src/main/resources/files/gradle/helidon/build.gradle.tpl
 src/main/resources/files/gradle/liberty/build.gradle.tpl
 src/main/resources/files/gradle/payara-micro/build.gradle.tpl
+src/main/resources/files/gradle/quarkus/build.gradle.tpl
+src/main/resources/files/gradle/quarkus/gradle.properties.tpl
+src/main/resources/files/gradle/quarkus/settings.gradle.tpl
 src/main/resources/files/gradle/settings.gradle.tpl
 src/main/resources/files/helidon/logging.properties.tpl
 src/main/resources/files/helidon/microprofile-config.properties.tpl

--- a/src/main/resources/files/TestSecureController.java.tpl
+++ b/src/main/resources/files/TestSecureController.java.tpl
@@ -38,7 +38,6 @@ public class TestSecureController {
             throw new WebApplicationException("Unable to read privateKey.pem", 500);
         }
         String jwt = generateJWT(key);
-        // any method to send a REST request with an appropriate header will work of course.
         WebTarget target = ClientBuilder.newClient().target("http://localhost:[# th:text="${port_service_b}"/]/data/protected");
         Response response = target.request().header("authorization", "Bearer " + jwt).buildGet().invoke();
         return String.format("Claim value within JWT of 'custom-value' : %s", response.readEntity(String.class));
@@ -55,15 +54,11 @@ public class TestSecureController {
         token.setAud("targetService");
         token.setIss("https://server.example.com");  // Must match the expected issues configuration values
         token.setJti(UUID.randomUUID().toString());
-
         token.setSub("Jessie");  // Sub is required for WildFly Swarm
         token.setUpn("Jessie");
-
         token.setIat(System.currentTimeMillis());
         token.setExp(System.currentTimeMillis() + 30000); // 30 Seconds expiration!
-
         token.addAdditionalClaims("custom-value", "Jessie specific value");
-
         token.setGroups(Arrays.asList("user", "protected"));
 
         return provider.generateToken(new io.vertx.core.json.JsonObject().mergeIn(token.toJSONString()), new JWTOptions().setAlgorithm("RS256"));

--- a/src/main/resources/files/gradle/build.gradle.tpl
+++ b/src/main/resources/files/gradle/build.gradle.tpl
@@ -3,8 +3,8 @@ apply plugin: 'war'
 group = '[# th:text="${maven_groupid}"/]'
 version = '1.0-SNAPSHOT'
 
-sourceCompatibility = [# th:text="${se_version}"/]
-targetCompatibility = [# th:text="${se_version}"/]
+sourceCompatibility = JavaVersion.VERSION_[# th:text="${se_version}"/]
+targetCompatibility = JavaVersion.VERSION_[# th:text="${se_version}"/]
 
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
@@ -17,7 +17,7 @@ repositories {
 dependencies {
     providedCompile 'org.eclipse.microprofile:microprofile:[# th:text="${mp_depversion}"/]'
     [# th:if="${mainProject and mp_JWT_auth}"]
-    implementation 'io.vertx:vertx-auth-jwt:3.9.2'
+    implementation 'io.vertx:vertx-auth-jwt:[# th:text="${vertx_auth_jwt_version}"/]'
     [/]
     [# th:if="${mainProject and mp_graphql}"]
     providedCompile 'org.eclipse.microprofile.graphql:microprofile-graphql-api:1.0.2'

--- a/src/main/resources/files/gradle/gradle-wrapper.properties.tpl
+++ b/src/main/resources/files/gradle/gradle-wrapper.properties.tpl
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/resources/files/gradle/helidon/build.gradle.tpl
+++ b/src/main/resources/files/gradle/helidon/build.gradle.tpl
@@ -8,8 +8,8 @@ version = '1.0-SNAPSHOT'
 
 description = "MicroProfile Starter example"
 
-sourceCompatibility = [# th:text="${se_version}"/]
-targetCompatibility = [# th:text="${se_version}"/]
+sourceCompatibility = JavaVersion.VERSION_[# th:text="${se_version}"/]
+targetCompatibility = JavaVersion.VERSION_[# th:text="${se_version}"/]
 
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
@@ -34,8 +34,7 @@ dependencies {
     runtimeOnly 'org.jboss:jandex'
     runtimeOnly 'jakarta.activation:jakarta.activation-api'
     [# th:if="${mainProject and mp_JWT_auth}"]
-    implementation 'io.vertx:vertx-auth-jwt:3.9.2'
-    [/]
+    implementation 'io.vertx:vertx-auth-jwt:[# th:text="${vertx_auth_jwt_version}"/]'[/]
 }
 
 // define a custom task to copy all dependencies in the runtime classpath

--- a/src/main/resources/files/gradle/liberty/build.gradle.tpl
+++ b/src/main/resources/files/gradle/liberty/build.gradle.tpl
@@ -7,8 +7,8 @@ version = '1.0-SNAPSHOT'
 
 description = "MicroProfile Starter example"
 
-sourceCompatibility = [# th:text="${se_version}"/]
-targetCompatibility = [# th:text="${se_version}"/]
+sourceCompatibility = JavaVersion.VERSION_[# th:text="${se_version}"/]
+targetCompatibility = JavaVersion.VERSION_[# th:text="${se_version}"/]
 
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
@@ -35,11 +35,9 @@ repositories {
 dependencies {
     providedCompile 'org.eclipse.microprofile:microprofile:[# th:text="${mp_depversion}"/]'
     [# th:if="${mainProject and mp_JWT_auth}"]
-    implementation 'io.vertx:vertx-auth-jwt:3.9.2'
-    [/]
+    implementation 'io.vertx:vertx-auth-jwt:[# th:text="${vertx_auth_jwt_version}"/]'[/]
     [# th:if="${mainProject and mp_graphql}"]
-    providedCompile 'org.eclipse.microprofile.graphql:microprofile-graphql-api:1.0.2'
-    [/]
+    providedCompile 'org.eclipse.microprofile.graphql:microprofile-graphql-api:1.0.2'[/]
 }
 
 ext  {

--- a/src/main/resources/files/gradle/payara-micro/build.gradle.tpl
+++ b/src/main/resources/files/gradle/payara-micro/build.gradle.tpl
@@ -7,8 +7,8 @@ version = '1.0-SNAPSHOT'
 
 description = "MicroProfile Starter example"
 
-sourceCompatibility = [# th:text="${se_version}"/]
-targetCompatibility = [# th:text="${se_version}"/]
+sourceCompatibility = JavaVersion.VERSION_[# th:text="${se_version}"/]
+targetCompatibility = JavaVersion.VERSION_[# th:text="${se_version}"/]
 
 payaraMicro {
     payaraVersion = '[# th:text="${payara_version}"/]'
@@ -21,11 +21,9 @@ payaraMicro {
 dependencies {
     providedCompile 'org.eclipse.microprofile:microprofile:[# th:text="${mp_depversion}"/]'
     [# th:if="${mainProject and mp_JWT_auth}"]
-    implementation 'io.vertx:vertx-auth-jwt:3.9.2'
-    [/]
+    implementation 'io.vertx:vertx-auth-jwt:[# th:text="${vertx_auth_jwt_version}"/]'[/]
     [# th:if="${mainProject and mp_graphql}"]
-    providedCompile 'org.eclipse.microprofile.graphql:microprofile-graphql-api:1.0.2'
-    [/]
+    providedCompile 'org.eclipse.microprofile.graphql:microprofile-graphql-api:1.0.2'[/]
 }
 
 repositories {

--- a/src/main/resources/files/gradle/quarkus/build.gradle.tpl
+++ b/src/main/resources/files/gradle/quarkus/build.gradle.tpl
@@ -1,0 +1,48 @@
+plugins {
+    id 'java'
+    id 'io.quarkus'
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencies {
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-arc'
+    implementation 'io.quarkus:quarkus-resteasy'
+    [# th:if="${mainProject and mp_fault_tolerance}"]
+    implementation 'io.quarkus:quarkus-smallrye-fault-tolerance'[/]
+    [# th:if="${mp_JWT_auth}"]
+    implementation 'io.quarkus:quarkus-smallrye-jwt'[/]
+    [# th:if="${mainProject and mp_metrics}"]
+    implementation 'io.quarkus:quarkus-smallrye-metrics'[/]
+    [# th:if="${mainProject and mp_health_checks}"]
+    implementation 'io.quarkus:quarkus-smallrye-health'[/]
+    [# th:if="${mainProject and mp_open_API}"]
+    implementation 'io.quarkus:quarkus-smallrye-openapi'[/]
+    [# th:if="${mp_open_tracing}"]
+    implementation 'io.quarkus:quarkus-smallrye-opentracing'[/]
+    [# th:if="${mainProject and (mp_rest_client or mp_JWT_auth)}"]
+    implementation 'io.quarkus:quarkus-rest-client'[/]
+    [# th:if="${mainProject and mp_JWT_auth}"]
+    implementation 'io.vertx:vertx-auth-jwt:[# th:text="${vertx_auth_jwt_version}"/]'[/]
+}
+
+group '[# th:text="${maven_groupid}"/]'
+description = "MicroProfile Starter example"
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_[# th:text="${se_version}"/]
+    targetCompatibility = JavaVersion.VERSION_[# th:text="${se_version}"/]
+}
+
+compileJava {
+    options.encoding = 'UTF-8'
+    options.compilerArgs << '-parameters'
+}
+
+compileTestJava {
+    options.encoding = 'UTF-8'
+}

--- a/src/main/resources/files/gradle/quarkus/gradle.properties.tpl
+++ b/src/main/resources/files/gradle/quarkus/gradle.properties.tpl
@@ -1,0 +1,6 @@
+#Gradle properties
+quarkusPluginId=io.quarkus
+quarkusPluginVersion=[# th:text="${quarkus_version}"/]
+quarkusPlatformGroupId=io.quarkus
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformVersion=[# th:text="${quarkus_version}"/]

--- a/src/main/resources/files/gradle/quarkus/settings.gradle.tpl
+++ b/src/main/resources/files/gradle/quarkus/settings.gradle.tpl
@@ -1,0 +1,11 @@
+pluginManagement {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+        id "${quarkusPluginId}" version "${quarkusPluginVersion}"
+    }
+}
+rootProject.name = '[# th:text="${maven_artifactid}"/]'

--- a/src/main/resources/files/quarkus/MetricController.java.tpl
+++ b/src/main/resources/files/quarkus/MetricController.java.tpl
@@ -48,7 +48,7 @@ public class MetricController {
     }
 
     @Gauge(name = "counter_gauge", unit = MetricUnits.NONE)
-    private long getCustomerCount() {
+    long getCustomerCount() {
         return counter.getCount();
     }
 }

--- a/src/main/resources/files/quarkus/application.properties.tpl
+++ b/src/main/resources/files/quarkus/application.properties.tpl
@@ -1,5 +1,6 @@
 injected.value=Injected value
 value=lookup value
+quarkus.package.output-name=[# th:text="${maven_artifactid}"/]
 [# th:if="${mp_rest_client}"]
 [# th:text="${java_package}"/].client.Service/mp-rest/url=http://localhost:[# th:text="${port_service_b}"/]/data/client/service
 [/]
@@ -12,4 +13,8 @@ quarkus.jaeger.service-name=Demo-Service-A
 quarkus.jaeger.sampler-type=const
 quarkus.jaeger.sampler-param=1
 quarkus.jaeger.endpoint=http://localhost:14268/api/traces
+[/]
+[# th:if="${mp_JWT_auth}"]
+# These options are needed only if you build your project into a native executable.
+quarkus.native.additional-build-args=-H:Log=registerResource:,-H:IncludeResources=privateKey.pem,--initialize-at-run-time=io.vertx.ext.auth.impl.jose.JWT
 [/]

--- a/src/main/resources/files/quarkus/mp3_x/index.html.tpl
+++ b/src/main/resources/files/quarkus/mp3_x/index.html.tpl
@@ -45,7 +45,8 @@
 
 [# th:if="${mp_open_tracing}"]
 <h3>Open Tracing</h3>
-If you have <pre>./jaeger-all-in-one</pre> running, open <a href="http://localhost:16686/">http://localhost:16686</a>
+If you have <pre>./jaeger-all-in-one</pre> running, open <a href="http://localhost:16686/">http://localhost:16686</a>. <br/>
+You can download <a href="https://www.jaegertracing.io/download/" target="_blank" >Jaeger</a> to try the tracing capability.
 [/]
 
 [# th:if="${mp_rest_client}"]

--- a/src/main/resources/files/quarkus/readme.md.secondary.tpl
+++ b/src/main/resources/files/quarkus/readme.md.secondary.tpl
@@ -3,33 +3,97 @@
 ## Introduction
 
 MicroProfile Starter has generated this MicroProfile application for you containing some endpoints which are called from the main application (see the `service-a` directory)
+[# th:if="${build_tool} == 'GRADLE'"]
+This project uses Quarkus, the Supersonic Subatomic Java Framework.
 
-The generation of the executable jar file can be performed by issuing the following command
+If you want to learn more about Quarkus, please visit its website: https://quarkus.io/ .
 
-    mvn clean compile package
+## Packaging and running the application
 
-This will create a jar file **[# th:text="${jar_file}"/]** within the _target_ maven folder. This can be started by executing the following command
+If you want to build an _über-jar_, execute the following command:
+
+    ./gradlew build -Dquarkus.package.type=uber-jar
+
+To run the application:
+
+    java [# th:text="${jar_parameters}"/] -jar build/[# th:text="${jar_file}"/]
+
+The application can be also packaged using simple:
+
+    ./gradlew build
+
+It produces the `quarkus-run.jar` file in the `build/quarkus-app/` directory.
+Be aware that it is not an _über-jar_ as the dependencies are copied into the `build/quarkus-app/lib/` directory.
+
+## Creating a native executable
+
+Mind having GRAALVM_HOME set to your Mandrel or GraalVM installation.
+
+You can create a native executable using:
+
+    ./gradlew build -Dquarkus.package.type=native
+
+Or, if you don't have [Mandrel](https://github.com/graalvm/mandrel/releases/) or
+[GraalVM](https://github.com/graalvm/graalvm-ce-builds/releases) installed, you can run the native executable
+build in a container using:
+
+    ./gradlew build -Dquarkus.package.type=native -Dquarkus.native.container-build=true
+
+Or to use Mandrel distribution:
+
+    ./gradlew build -Dquarkus.package.type=native -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel:20.3-java11
+
+You can then execute your native executable with:
+
+    ./build/[# th:text="${jar_file_no_suffix}"/] [# th:text="${jar_parameters}"/]
+
+If you want to learn more about building native executables, please consult https://quarkus.io/guides/building-native-image.
+[/][# th:if="${build_tool} == 'MAVEN'"]
+This project uses Quarkus, the Supersonic Subatomic Java Framework.
+
+If you want to learn more about Quarkus, please visit its website: https://quarkus.io/ .
+
+## Packaging and running the application
+
+If you want to build an _über-jar_, execute the following command:
+
+    mvn package -Dquarkus.package.type=uber-jar
+
+To run the application:
 
     java [# th:text="${jar_parameters}"/] -jar target/[# th:text="${jar_file}"/]
 
-You can also start the project in development mode where it automatically updates code on the fly as you save your files:
+The application can be also packaged using simple:
 
-    mvn [# th:text="${jar_parameters}"/] clean compile quarkus:dev
+    mvn package
 
-Last but not least, you can build the whole application into a one statically linked executable that does not require JVM:
+It produces the `quarkus-run.jar` file in the `target/quarkus-app/` directory.
+Be aware that it is not an _über-jar_ as the dependencies are copied into the `target/quarkus-app/lib/` directory.
 
-    mvn clean compile package -Pnative
+## Creating a native executable
 
-Native executable build might take a minute. Then you can execute it on a compatible architecture without JVM:
+Mind having GRAALVM_HOME set to your Mandrel or GraalVM installation.
+
+You can create a native executable using:
+
+    mvn package -Dquarkus.package.type=native
+
+Or, if you don't have [Mandrel](https://github.com/graalvm/mandrel/releases/) or
+[GraalVM](https://github.com/graalvm/graalvm-ce-builds/releases) installed, you can run the native executable
+build in a container using:
+
+    mvn package -Dquarkus.package.type=native -Dquarkus.native.container-build=true
+
+Or to use Mandrel distribution:
+
+    mvn package -Dquarkus.package.type=native -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel:20.3-java11
+
+You can then execute your native executable with:
 
     ./target/[# th:text="${jar_file_no_suffix}"/] [# th:text="${jar_parameters}"/]
 
-## Note on Native image
-
- * You need GraalVM installed from the GraalVM web site. Using the community edition is enough. Version 19.1.1+ is required.
- * The GRAALVM_HOME environment variable configured appropriately
- * The native-image tool must be installed; this can be done by running ```gu install native-image``` from your GraalVM directory
-
+If you want to learn more about building native executables, please consult https://quarkus.io/guides/building-native-image.
+[/]
 ## Specification examples
 
 [# th:if="${mp_JWT_auth}"]
@@ -40,14 +104,8 @@ The **ProtectedController** contains the protected endpoint since it contains th
 
 The _TestSecureController_ code creates a JWT based on the private key found within the resource directory.
 However, any method to send a REST request with an appropriate header will work of course. Please feel free to change this code to your needs.
-
-[/]
-
-[# th:if="${mp_rest_client}"]
+[/][# th:if="${mp_rest_client}"]
 ### Rest Client
-
 A type safe invocation of HTTP rest endpoints. Specification [here](https://microprofile.io/project/eclipse/microprofile-rest-client)
-
 The example calls one endpoint from another JAX-RS resource where generated Rest Client is injected as CDI bean.
-
 [/]

--- a/src/main/resources/files/quarkus/readme.md.tpl
+++ b/src/main/resources/files/quarkus/readme.md.tpl
@@ -3,38 +3,121 @@
 ## Introduction
 
 MicroProfile Starter has generated this MicroProfile application for you.
+[# th:if="${build_tool} == 'GRADLE'"]
+This project uses Quarkus, the Supersonic Subatomic Java Framework.
 
-The generation of the executable jar file can be performed by issuing the following command
+If you want to learn more about Quarkus, please visit its website: https://quarkus.io/ .
 
-    mvn clean compile package
+## Packaging and running the application
 
-This will create a jar file **[# th:text="${jar_file}"/]** within the _target_ maven folder. This can be started by executing the following command
+If you want to build an _über-jar_, execute the following command:
 
-    java -jar target/[# th:text="${jar_file}"/]
+    ./gradlew build -Dquarkus.package.type=uber-jar
 
-You can also start the project in development mode where it automatically updates code on the fly as you save your files:
+To run the application:
 
-    mvn clean compile quarkus:dev
+    java -jar build/[# th:text="${jar_file}"/]
 
-Last but not least, you can build the whole application into a one statically linked executable that does not require JVM:
+The application can be also packaged using simple:
 
-    mvn clean compile package -Pnative
+    ./gradlew build
 
-Native executable build might take a minute. Then you can execute it on a compatible architecture without JVM:
-
-    ./target/[# th:text="${jar_file_no_suffix}"/]
+It produces the `quarkus-run.jar` file in the `build/quarkus-app/` directory.
+Be aware that it is not an _über-jar_ as the dependencies are copied into the `build/quarkus-app/lib/` directory.
 
 To launch the test page, open your browser at the following URL
 
     http://localhost:[# th:text="${port_service_a}"/]/index.html
 
-## Note on Native image
+## Running the application in dev mode
 
- * You need GraalVM installed from the GraalVM web site. Using the community edition is enough. Version 19.1.1+ is required.
- * The GRAALVM_HOME environment variable configured appropriately
- * The native-image tool must be installed; this can be done by running ```gu install native-image``` from your GraalVM directory
- * To read more about Quarkus and Native image, see https://quarkus.io/guides/building-native-image-guide
+You can run your application in dev mode that enables live coding using:
 
+    ./gradlew quarkusDev
+
+> **_NOTE:_**  Quarkus now ships with a Dev UI, which is available in dev mode only at http://localhost:8080/q/dev/.
+
+## Creating a native executable
+
+Mind having GRAALVM_HOME set to your Mandrel or GraalVM installation.
+
+You can create a native executable using:
+
+    ./gradlew build -Dquarkus.package.type=native
+
+Or, if you don't have [Mandrel](https://github.com/graalvm/mandrel/releases/) or
+[GraalVM](https://github.com/graalvm/graalvm-ce-builds/releases) installed, you can run the native executable
+build in a container using:
+
+    ./gradlew build -Dquarkus.package.type=native -Dquarkus.native.container-build=true
+
+Or to use Mandrel distribution:
+
+    ./gradlew build -Dquarkus.package.type=native -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel:20.3-java11
+
+You can then execute your native executable with:
+
+    ./build/[# th:text="${jar_file_no_suffix}"/]
+
+If you want to learn more about building native executables, please consult https://quarkus.io/guides/building-native-image.
+[/][# th:if="${build_tool} == 'MAVEN'"]
+This project uses Quarkus, the Supersonic Subatomic Java Framework.
+
+If you want to learn more about Quarkus, please visit its website: https://quarkus.io/ .
+
+## Packaging and running the application
+
+If you want to build an _über-jar_, execute the following command:
+
+    mvn package -Dquarkus.package.type=uber-jar
+
+To run the application:
+
+    java -jar target/[# th:text="${jar_file}"/]
+
+The application can be also packaged using simple:
+
+    mvn package
+
+It produces the `quarkus-run.jar` file in the `target/quarkus-app/` directory.
+Be aware that it is not an _über-jar_ as the dependencies are copied into the `target/quarkus-app/lib/` directory.
+
+To launch the test page, open your browser at the following URL
+
+    http://localhost:[# th:text="${port_service_a}"/]/index.html
+
+## Running the application in dev mode
+
+You can run your application in dev mode that enables live coding using:
+
+    mvn compile quarkus:dev
+
+> **_NOTE:_**  Quarkus now ships with a Dev UI, which is available in dev mode only at http://localhost:8080/q/dev/.
+
+## Creating a native executable
+
+Mind having GRAALVM_HOME set to your Mandrel or GraalVM installation.
+
+You can create a native executable using:
+
+    mvn package -Dquarkus.package.type=native
+
+Or, if you don't have [Mandrel](https://github.com/graalvm/mandrel/releases/) or
+[GraalVM](https://github.com/graalvm/graalvm-ce-builds/releases) installed, you can run the native executable
+build in a container using:
+
+    mvn package -Dquarkus.package.type=native -Dquarkus.native.container-build=true
+
+Or to use Mandrel distribution:
+
+    mvn package -Dquarkus.package.type=native -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel:20.3-java11
+
+You can then execute your native executable with:
+
+    ./target/[# th:text="${jar_file_no_suffix}"/]
+
+If you want to learn more about building native executables, please consult https://quarkus.io/guides/building-native-image.
+[/]
 ## Specification examples
 
 By default, there is always the creation of a JAX-RS application class to define the path on which the JAX-RS endpoints are available.
@@ -42,40 +125,31 @@ By default, there is always the creation of a JAX-RS application class to define
 Also, a simple Hello world endpoint is created, have a look at the class **HelloController**.
 
 More information on MicroProfile can be found [here](https://microprofile.io/)
-
 [# th:if="${mp_config}"]
 ### Config
 
 Configuration of your application parameters. Specification [here](https://microprofile.io/project/eclipse/microprofile-config)
 
 The example class **ConfigTestController** shows you how to inject a configuration parameter and how you can retrieve it programmatically.
-[/]
-
-[# th:if="${mp_fault_tolerance}"]
+[/][# th:if="${mp_fault_tolerance}"]
 ### Fault tolerance
 
 Add resilient features to your applications like TimeOut, RetryPolicy, Fallback, bulkhead and circuit breaker. Specification [here](https://microprofile.io/project/eclipse/microprofile-fault-tolerance)
 
 The example class **ResilienceController** has an example of a FallBack mechanism where an fallback result is returned when the execution takes too long.
-[/]
-
-[# th:if="${mp_health_checks}"]
+[/][# th:if="${mp_health_checks}"]
 ### Health
 
 The health status can be used to determine if the 'computing node' needs to be discarded/restarted or not. Specification [here](https://microprofile.io/project/eclipse/microprofile-health)
 
 The class **ServiceHealthCheck** contains an example of a custom check which can be integrated to health status checks of the instance.  The index page contains a link to the status data.
-[/]
-
-[# th:if="${mp_metrics}"]
+[/][# th:if="${mp_metrics}"]
 ### Metrics
 
 The Metrics exports _Telemetric_ data in a uniform way of system and custom resources. Specification [here](https://microprofile.io/project/eclipse/microprofile-metrics)
 
 The example class **MetricController** contains an example how you can measure the execution time of a request.  The index page also contains a link to the metric page (with all metric info)
-[/]
-
-[# th:if="${mp_JWT_auth}"]
+[/][# th:if="${mp_JWT_auth}"]
 ### JWT Auth
 
 Using the OpenId Connect JWT token to pass authentication and authorization information to the JAX-RS endpoint. Specification [here](https://microprofile.io/project/eclipse/microprofile-rest-client)
@@ -85,32 +159,22 @@ The **ProtectedController** (secondary application) contains the protected endpo
 
 The _TestSecureController_ code creates a JWT based on the private key found within the resource directory.
 However, any method to send a REST request with an appropriate header will work of course. Please feel free to change this code to your needs.
-[/]
-
-[# th:if="${mp_open_API}"]
+[/][# th:if="${mp_open_API}"]
 ### Open API
 
 Exposes the information about your endpoints in the format of the OpenAPI v3 specification. Specification [here](https://microprofile.io/project/eclipse/microprofile-open-api)
 
 The index page contains a link to the OpenAPI information of your endpoints.
-
-[/]
-
-[# th:if="${mp_open_tracing}"]
+[/][# th:if="${mp_open_tracing}"]
 ### Open Tracing
 
 Allow the participation in distributed tracing of your requests through various micro services. Specification [here](https://microprofile.io/project/eclipse/microprofile-opentracing)
 
 To show this capability download [Jaeger](https://www.jaegertracing.io/download/#binaries) and run ```./jaeger-all-in-one```.
 Open [http://localhost:16686/](http://localhost:16686/) to see the traces. Mind that you have to access your demo app endpoint for any traces to show on Jaeger UI.
-
-[/]
-
-[# th:if="${mp_rest_client}"]
+[/][# th:if="${mp_rest_client}"]
 ### Rest Client
 
 A type safe invocation of HTTP rest endpoints. Specification [here](https://microprofile.io/project/eclipse/microprofile-rest-client)
 
-The example calls one endpoint from another JAX-RS resource where generated Rest Client is injected as CDI bean.
-
-[/]
+The example calls one endpoint from another JAX-RS resource where generated Rest Client is injected as CDI bean.[/]

--- a/src/main/resources/files/quarkus/service-b/application.properties.tpl
+++ b/src/main/resources/files/quarkus/service-b/application.properties.tpl
@@ -1,4 +1,5 @@
 quarkus.ssl.native=true
+quarkus.package.output-name=[# th:text="${maven_artifactid}"/]
 [# th:if="${mp_JWT_auth}"]
 mp.jwt.verify.publickey.location=META-INF/resources/publicKey.pem
 mp.jwt.verify.issuer=https://server.example.com

--- a/src/main/resources/files/readme.md.tpl
+++ b/src/main/resources/files/readme.md.tpl
@@ -13,15 +13,12 @@ This will create an executable jar file **[# th:text="${jar_file}"/]** within th
 
     java -jar target/[# th:text="${jar_file}"/]
 
-[/]
-[# th:if="${build_tool} == 'GRADLE'"]
+[/][# th:if="${build_tool} == 'GRADLE'"]
 [# th:if="${mp_servername} == 'payara-micro'"]
     ./gradlew microBundle
-[/]
-[# th:if="${mp_servername} == 'liberty'"]
+[/][# th:if="${mp_servername} == 'liberty'"]
     ./gradlew libertyPackage
-[/]
-[# th:if="${mp_servername} == 'helidon'"]
+[/][# th:if="${mp_servername} == 'helidon'"]
     ./gradlew assemble
 [/]
 
@@ -29,15 +26,11 @@ This will create an executable jar file **[# th:text="${jar_file}"/]** within th
 
 [# th:if="${mp_servername} == 'payara-micro'"]
     ./gradlew microStart
-[/]
-[# th:if="${mp_servername} == 'liberty'"]
+[/][# th:if="${mp_servername} == 'liberty'"]
     ./gradlew libertyRun --no-daemon
-[/]
-[# th:if="${mp_servername} == 'helidon'"]
+[/][# th:if="${mp_servername} == 'helidon'"]
     java -jar build/libs/[# th:text="${jar_file}"/]
-[/]
-[/]
-
+[/][/]
 [# th:if="${mp_servername} == 'liberty'"]
 ### Liberty Dev Mode
 
@@ -82,33 +75,25 @@ More information on MicroProfile can be found [here](https://microprofile.io/)
 Configuration of your application parameters. Specification [here](https://microprofile.io/project/eclipse/microprofile-config)
 
 The example class **ConfigTestController** shows you how to inject a configuration parameter and how you can retrieve it programmatically.
-[/]
-
-[# th:if="${mp_fault_tolerance}"]
+[/][# th:if="${mp_fault_tolerance}"]
 ### Fault tolerance
 
 Add resilient features to your applications like TimeOut, RetryPolicy, Fallback, bulkhead and circuit breaker. Specification [here](https://microprofile.io/project/eclipse/microprofile-fault-tolerance)
 
 The example class **ResilienceController** has an example of a FallBack mechanism where an fallback result is returned when the execution takes too long.
-[/]
-
-[# th:if="${mp_health_checks}"]
+[/][# th:if="${mp_health_checks}"]
 ### Health
 
 The health status can be used to determine if the 'computing node' needs to be discarded/restarted or not. Specification [here](https://microprofile.io/project/eclipse/microprofile-health)
 
 The class **ServiceHealthCheck** contains an example of a custom check which can be integrated to health status checks of the instance.  The index page contains a link to the status data.
-[/]
-
-[# th:if="${mp_metrics}"]
+[/][# th:if="${mp_metrics}"]
 ### Metrics
 
 The Metrics exports _Telemetric_ data in a uniform way of system and custom resources. Specification [here](https://microprofile.io/project/eclipse/microprofile-metrics)
 
 The example class **MetricController** contains an example how you can measure the execution time of a request.  The index page also contains a link to the metric page (with all metric info)
-[/]
-
-[# th:if="${mp_JWT_auth}"]
+[/][# th:if="${mp_JWT_auth}"]
 ### JWT Auth
 
 Using the OpenId Connect JWT token to pass authentication and authorization information to the JAX-RS endpoint. Specification [here](https://microprofile.io/project/eclipse/microprofile-rest-client)
@@ -118,18 +103,13 @@ The **ProtectedController** (secondary application) contains the protected endpo
 
 The _TestSecureController_ code creates a JWT based on the private key found within the resource directory.
 However, any method to send a REST request with an appropriate header will work of course. Please feel free to change this code to your needs.
-[/]
-
-[# th:if="${mp_open_API}"]
+[/][# th:if="${mp_open_API}"]
 ### Open API
 
 Exposes the information about your endpoints in the format of the OpenAPI v3 specification. Specification [here](https://microprofile.io/project/eclipse/microprofile-open-api)
 
 The index page contains a link to the OpenAPI information of your endpoints.
-
-[/]
-
-[# th:if="${mp_open_tracing}"]
+[/][# th:if="${mp_open_tracing}"]
 ### Open Tracing
 
 Allow the participation in distributed tracing of your requests through various micro services. Specification [here](https://microprofile.io/project/eclipse/microprofile-opentracing)
@@ -139,18 +119,13 @@ Alternatively, you can download the docker image of `all-in-one` using ```docker
 followed by running the docker image. Refer to [Jaeger doc](https://www.jaegertracing.io/docs/) for more info.
 
 Open [http://localhost:16686/](http://localhost:16686/) to see the traces. You have to invoke your demo app endpoint for any traces to show on Jaeger UI.
-[/]
-[/]
-
-[# th:if="${mp_rest_client}"]
+[/][/][# th:if="${mp_rest_client}"]
 ### Rest Client
 
 A type safe invocation of HTTP rest endpoints. Specification [here](https://microprofile.io/project/eclipse/microprofile-rest-client)
 
 The example calls one endpoint from another JAX-RS resource where generated Rest Client is injected as CDI bean.
-[/]
-
-[# th:if="${mp_graphql}"]
+[/][# th:if="${mp_graphql}"]
 ### GraphQL
 
 GraphQL is a remote data query language initially invented by Facebook and now evolving under it's own specification and community. MicroProfile GraphQL provides annotation-based APIs for building GraphQL services in Java. The specification is available [here](https://microprofile.io/project/eclipse/microprofile-graphql).
@@ -169,5 +144,4 @@ query allHeroes {
     }
 }
 ```
-[/]
-[/]
+[/][/]

--- a/src/main/resources/pom-servers.xml
+++ b/src/main/resources/pom-servers.xml
@@ -33,7 +33,6 @@
     <artifactId>microprofile-server</artifactId>
     <version>1.0-SNAPSHOT</version>
 
-
     <profiles>
         <profile>
             <id>wildfly-swarm-1.2</id>
@@ -111,7 +110,7 @@
                     <plugin>
                         <groupId>org.wildfly.plugins</groupId>
                         <artifactId>wildfly-jar-maven-plugin</artifactId>
-                        <version>1.0.0.Alpha4</version>
+                        <version>2.0.2.Final</version>
                         <configuration>
                             <feature-pack-location>
                                 wildfly@maven(org.jboss.universe:community-universe)#${version.wildfly}
@@ -158,7 +157,6 @@
                         <groupId>io.thorntail</groupId>
                         <artifactId>thorntail-maven-plugin</artifactId>
                         <version>${version.thorntail}</version>
-
                         <executions>
                             <execution>
                                 <goals>
@@ -166,21 +164,29 @@
                                 </goals>
                             </execution>
                         </executions>
-
                     </plugin>
-
                 </plugins>
-
             </build>
         </profile>
+
         <profile>
             <id>quarkus</id>
+            <properties>
+                <compiler-plugin.version>3.8.1</compiler-plugin.version>
+                <maven.compiler.parameters>true</maven.compiler.parameters>
+                <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+                <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+                <quarkus-plugin.version>${version.quarkus}</quarkus-plugin.version>
+                <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+                <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+                <quarkus.platform.version>${version.quarkus}</quarkus.platform.version>
+            </properties>
             <dependencyManagement>
                 <dependencies>
                     <dependency>
-                        <groupId>io.quarkus</groupId>
-                        <artifactId>quarkus-universe-bom</artifactId>
-                        <version>${version.quarkus}</version>
+                        <groupId>${quarkus.platform.group-id}</groupId>
+                        <artifactId>${quarkus.platform.artifact-id}</artifactId>
+                        <version>${quarkus.platform.version}</version>
                         <type>pom</type>
                         <scope>import</scope>
                     </dependency>
@@ -193,19 +199,23 @@
                     <plugin>
                         <groupId>io.quarkus</groupId>
                         <artifactId>quarkus-maven-plugin</artifactId>
-                        <version>${version.quarkus}</version>
+                        <version>${quarkus-plugin.version}</version>
+                        <extensions>true</extensions>
                         <executions>
                             <execution>
                                 <goals>
-                                    <goal>prepare</goal>
                                     <goal>build</goal>
+                                    <goal>generate-code</goal>
                                 </goals>
                             </execution>
                         </executions>
                     </plugin>
                     <plugin>
                         <artifactId>maven-compiler-plugin</artifactId>
-                        <version>3.8.1</version>
+                        <version>${compiler-plugin.version}</version>
+                        <configuration>
+                            <parameters>${maven.compiler.parameters}</parameters>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/src/test/java/org/eclipse/microprofile/starter/core/TemplateVariableProviderTest.java
+++ b/src/test/java/org/eclipse/microprofile/starter/core/TemplateVariableProviderTest.java
@@ -19,10 +19,10 @@
  */
 package org.eclipse.microprofile.starter.core;
 
-import org.eclipse.microprofile.starter.core.model.JessieMaven;
-import org.eclipse.microprofile.starter.core.model.JessieModel;
 import org.eclipse.microprofile.starter.core.model.BuildTool;
 import org.eclipse.microprofile.starter.core.model.JavaSEVersion;
+import org.eclipse.microprofile.starter.core.model.JessieMaven;
+import org.eclipse.microprofile.starter.core.model.JessieModel;
 import org.eclipse.microprofile.starter.core.model.JessieSpecification;
 import org.eclipse.microprofile.starter.core.model.MicroProfileVersion;
 import org.junit.Assert;


### PR DESCRIPTION
Overhauled the whole Quarkus support and bought it up to 1.7.0.Final -> 1.7.6.Final.
Significant work on readme docs so as Quarkus users are comfortable with both Maven and Gradle, including the build into
a native executable. Docs heavily inspired by code.quarkus.io/.

* Gradle needed an update, although Payara, Liberty and Helidon seem to be fine with that :heavy_check_mark: .
* I updated JWT token signing. No reason for an alarm, it is a version bump in the *generated code*, not in this project itself.
* Quarkus generated examples support Gradle now.
* Updated CI
