### PR TITLE
Use Helidon 2.3.1 for MP 3.3

### DIFF
--- a/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/server/HelidonServer.java
+++ b/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/server/HelidonServer.java
@@ -124,7 +124,7 @@ public class HelidonServer extends AbstractMicroprofileAddon {
             case NONE:
                 break;
             case MP33:
-                helidonVersion = "2.3.0";
+                helidonVersion = "2.3.1";
                 mpVersion = "3.3";
                 break;
             case MP32:


### PR DESCRIPTION
Resolves #432 

Helidon has released 2.3.1. This PR updates the starter to use that release for MP 3.3.

Signed-off-by: tim.quinn@oracle.com <tim.quinn@oracle.com>