### PR TITLE
Use Helidon 2.4.1 for generated code

### DIFF
--- a/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/server/HelidonServer.java
+++ b/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/server/HelidonServer.java
@@ -124,7 +124,7 @@ public class HelidonServer extends AbstractMicroprofileAddon {
             case NONE:
                 break;
             case MP33:
-                helidonVersion = "2.3.2";
+                helidonVersion = "2.4.1";
                 mpVersion = "3.3";
                 break;
             case MP32:

--- a/src/main/resources/files/helidon/RestApplication.java.tpl
+++ b/src/main/resources/files/helidon/RestApplication.java.tpl
@@ -1,5 +1,8 @@
 package [# th:text="${java_package}"/];
 
+[# th:if="${mp_open_API}"]
+import [# th:text="${java_package}"/].openapi.BookingController;
+[/]
 [# th:if="${mp_config}"]
 import [# th:text="${java_package}"/].config.ConfigTestController;
 [/]
@@ -35,6 +38,9 @@ public class [# th:text="${application}"/]RestApplication extends Application {
 
         // resources
         classes.add(HelloController.class);
+        [# th:if="${mp_open_API}"]
+        classes.add(BookingController.class);
+        [/]
         [# th:if="${mp_config}"]
         classes.add(ConfigTestController.class);
         [/]


### PR DESCRIPTION
Resolves #462 

Update the starter so generated code uses Helidon 2.4.1.

Signed-off-by: tim.quinn@oracle.com <tim.quinn@oracle.com>