### PR TITLE
Update supported Helidon releases; add SE 17 info along the way

### DIFF
--- a/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/model/JDKSelector.java
+++ b/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/model/JDKSelector.java
@@ -60,7 +60,8 @@ public class JDKSelector {
         fillJavaSEVersion(data, SupportedServer.TOMEE, JavaSEVersion.SE8, null, null);  // Supported for all MPVersions
 
         fillJavaSEVersion(data, SupportedServer.HELIDON, JavaSEVersion.SE8, null, MicroProfileVersion.MP30);  // Supported until MP 3.2
-        fillJavaSEVersion(data, SupportedServer.HELIDON, JavaSEVersion.SE11, MicroProfileVersion.MP32, null);  // Supported from MP 3.2
+        fillJavaSEVersion(data, SupportedServer.HELIDON, JavaSEVersion.SE11, MicroProfileVersion.MP32, MicroProfileVersion.MP33);
+        fillJavaSEVersion(data, SupportedServer.HELIDON, JavaSEVersion.SE17, MicroProfileVersion.MP50, null);
 
     }
 

--- a/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/model/SupportedServer.java
+++ b/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/model/SupportedServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -106,7 +106,7 @@ public enum SupportedServer {
             , false)  // GradleSupport
     , HELIDON("helidon", "Helidon",
             Arrays.asList(MicroProfileVersion.MP12, MicroProfileVersion.MP22, MicroProfileVersion.MP30
-                    , MicroProfileVersion.MP32, MicroProfileVersion.MP33)
+                    , MicroProfileVersion.MP32, MicroProfileVersion.MP33, MicroProfileVersion.MP50)
             , "%s.jar" //jarFileName
             , "" //jarParameters // Done by secondary/helidon/microprofile-config.properties
             , "8080" //portServiceA

--- a/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/server/HelidonServer.java
+++ b/src/main/java/org/eclipse/microprofile/starter/addon/microprofile/servers/server/HelidonServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019-2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -123,8 +123,12 @@ public class HelidonServer extends AbstractMicroprofileAddon {
 
             case NONE:
                 break;
+            case MP50:
+                helidonVersion = "3.1.0";
+                mpVersion = "5.0";
+                break;
             case MP33:
-                helidonVersion = "2.4.2";
+                helidonVersion = "2.5.5";
                 mpVersion = "3.3";
                 break;
             case MP32:

--- a/src/main/java/org/eclipse/microprofile/starter/core/model/JavaSEVersion.java
+++ b/src/main/java/org/eclipse/microprofile/starter/core/model/JavaSEVersion.java
@@ -29,7 +29,8 @@ public enum JavaSEVersion implements ComboBoxItem {
     // @formatter:off
     NONE(null, ""),
     SE8("1.8", "Java 8"),
-    SE11("11", "Java 11");
+    SE11("11", "Java 11"),
+    SE17("17", "Java 17");
     // @formatter:on
 
     private String code;


### PR DESCRIPTION
Resolves #478 

1. Add JDK 17 as a Java version.
2. Update which Helidon releases support which MP releases.