### PR TITLE
Remove outputDirectory from liberty-maven-plugin config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -397,9 +397,6 @@
                                     <goal>deploy</goal>
                                     <goal>package</goal>
                                 </goals>
-                                <configuration>
-                                    <outputDirectory>target/wlp-package</outputDirectory>
-                                </configuration>
                             </execution>
                         </executions>
                         <configuration>

--- a/src/main/resources/pom-servers.xml
+++ b/src/main/resources/pom-servers.xml
@@ -264,9 +264,6 @@
                                     <goal>deploy</goal>
                                     <goal>package</goal>
                                 </goals>
-                                <configuration>
-                                    <outputDirectory>target/wlp-package</outputDirectory>
-                                </configuration>
                             </execution>
                         </executions>
                         <configuration>


### PR DESCRIPTION
This config shouldn't be needed with newer versions of liberty-maven-plugin.

The [doc](https://github.com/OpenLiberty/ci.maven/blob/master/docs/common-parameters.md#common-parameters) points out the default config already incorporates a special case 

> The default value for the package and install-feature goals is ${project.build.directory}/liberty-alt-output-dir.

Given the issues we have with `<outputDirectory>` config... https://github.com/OpenLiberty/ci.maven/issues/1684 (which are mostly confined to dev mode, but the confusion may still bubble up into other cases)... I think we should just delete this config. 